### PR TITLE
Fj 2024 lesson 8

### DIFF
--- a/.github/workflows/currencyService.yaml
+++ b/.github/workflows/currencyService.yaml
@@ -1,9 +1,9 @@
 name: Build Currency service with tests
 
 on:
-  workflow_dispatch:
   pull_request:
-
+    branches:
+      - no
 
 jobs:
   build:

--- a/.github/workflows/customLinkedList.yaml
+++ b/.github/workflows/customLinkedList.yaml
@@ -1,10 +1,9 @@
 name: Build CustomLinkedList with tests
 
 on:
-  workflow_dispatch:
   pull_request:
     branches:
-      - main
+      - no
 
 
 jobs:

--- a/.github/workflows/kudaGo.yaml
+++ b/.github/workflows/kudaGo.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - fj_2024_lesson_8
 
 
 jobs:

--- a/.github/workflows/kudaGo.yaml
+++ b/.github/workflows/kudaGo.yaml
@@ -42,4 +42,3 @@ jobs:
           min-coverage-changed-files: 70
           title: Code Coverage
           update-comment: true
-

--- a/.github/workflows/kudaGo.yaml
+++ b/.github/workflows/kudaGo.yaml
@@ -7,7 +7,6 @@ on:
       - main
       - fj_2024_lesson_8
 
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,6 +14,21 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: kudago
+          POSTGRES_USER: kudago
+          POSTGRES_PASSWORD: kudago
+        ports:
+          - 5555:5432
+        options: >-
+          --health-cmd "pg_isready -U kudago"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v4

--- a/CurrencyService/src/main/resources/application.yaml
+++ b/CurrencyService/src/main/resources/application.yaml
@@ -14,7 +14,7 @@ management:
 
 app:
   client:
-    url: https://www.cbr.ru/scriфpts/XML_daily.asp
+    url: https://www.cbr.ru/scripts/XML_daily.asp
 
 resilience4j:
   circuitbreaker:

--- a/KudaGo/.env
+++ b/KudaGo/.env
@@ -1,0 +1,4 @@
+HOST=localhost:5555
+DB_NAME=kudago
+DB_USER=kudago
+DB_PASSWORD=kudago

--- a/KudaGo/build.gradle.kts
+++ b/KudaGo/build.gradle.kts
@@ -13,6 +13,7 @@ val wiremockTestcontainersVersion: String by project
 val wiremockVersion: String by project
 val testcontainersVersion: String by project
 val googleGuavaVersion: String by project
+val swaggerVersion: String by project
 
 jacoco {
 	toolVersion = "0.8.12"
@@ -38,9 +39,11 @@ dependencies {
 	implementation(project(":starter"))
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-devtools")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.aspectj:aspectjweaver:${aspectVersion}")
 	implementation("org.aspectj:aspectjrt:${aspectVersion}")
 	implementation("com.google.guava:guava:${googleGuavaVersion}")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${swaggerVersion}")
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 	annotationProcessor("org.projectlombok:lombok")

--- a/KudaGo/build.gradle.kts
+++ b/KudaGo/build.gradle.kts
@@ -12,6 +12,7 @@ val aspectVersion: String by project
 val wiremockTestcontainersVersion: String by project
 val wiremockVersion: String by project
 val testcontainersVersion: String by project
+val googleGuavaVersion: String by project
 
 jacoco {
 	toolVersion = "0.8.12"
@@ -39,6 +40,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-devtools")
 	implementation("org.aspectj:aspectjweaver:${aspectVersion}")
 	implementation("org.aspectj:aspectjrt:${aspectVersion}")
+	implementation("com.google.guava:guava:${googleGuavaVersion}")
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 	annotationProcessor("org.projectlombok:lombok")

--- a/KudaGo/build.gradle.kts
+++ b/KudaGo/build.gradle.kts
@@ -52,9 +52,12 @@ dependencies {
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 	testImplementation("org.wiremock:wiremock-standalone:${wiremockVersion}")
 	testImplementation("org.wiremock.integrations.testcontainers:wiremock-testcontainers-module:${wiremockTestcontainersVersion}")
 	testImplementation("org.testcontainers:junit-jupiter:${testcontainersVersion}")
+	testImplementation("org.testcontainers:postgresql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/KudaGo/build.gradle.kts
+++ b/KudaGo/build.gradle.kts
@@ -33,6 +33,9 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven {
+		url = uri("https://repo.kaczmarzyk.net")
+	}
 }
 
 dependencies {
@@ -44,6 +47,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-devtools")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
+	implementation("net.kaczmarzyk:specification-arg-resolver:3.1.0")
 	implementation("org.aspectj:aspectjweaver:${aspectVersion}")
 	implementation("org.aspectj:aspectjrt:${aspectVersion}")
 	implementation("com.google.guava:guava:${googleGuavaVersion}")

--- a/KudaGo/build.gradle.kts
+++ b/KudaGo/build.gradle.kts
@@ -38,6 +38,7 @@ repositories {
 dependencies {
 	implementation(project(":starter"))
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	implementation("org.springframework.data:spring-data-commons")
 	runtimeOnly("org.postgresql:postgresql")
 	implementation("org.liquibase:liquibase-core")
 	implementation("org.springframework.boot:spring-boot-starter-web")

--- a/KudaGo/build.gradle.kts
+++ b/KudaGo/build.gradle.kts
@@ -37,6 +37,9 @@ repositories {
 
 dependencies {
 	implementation(project(":starter"))
+	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+	runtimeOnly("org.postgresql:postgresql")
+	implementation("org.liquibase:liquibase-core")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-devtools")
 	implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/KudaGo/build.gradle.kts
+++ b/KudaGo/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
 	implementation("org.aspectj:aspectjweaver:${aspectVersion}")
 	implementation("org.aspectj:aspectjrt:${aspectVersion}")
 	implementation("com.google.guava:guava:${googleGuavaVersion}")
+	implementation ("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:${swaggerVersion}")
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")

--- a/KudaGo/compose.yaml
+++ b/KudaGo/compose.yaml
@@ -1,0 +1,40 @@
+networks:
+  backend: { }
+
+volumes:
+  postgresql: { }
+
+services:
+  postgresql:
+    image: postgres:15
+    environment:
+      - POSTGRES_DB=kudago
+      - POSTGRES_PASSWORD=kudago
+      - POSTGRES_USER=kudago
+    ports:
+      - "5555:5432"
+    volumes:
+      - postgresql:/var/lib/postgresql/data
+    networks:
+      - backend
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U kudago" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  liquibase-migrations:
+    image: liquibase/liquibase:4.25
+    depends_on:
+      - postgresql
+    command:
+      - --changelog-file=changelog-master.yaml
+      - --driver=org.postgresql.Driver
+      - --url=jdbc:postgresql://postgresql:5432/kudago
+      - --username=kudago
+      - --password=kudago
+      - update
+    volumes:
+      - ./src/main/resources/db/changelog:/liquibase/changelog
+    networks:
+      - backend

--- a/KudaGo/gradle.properties
+++ b/KudaGo/gradle.properties
@@ -2,3 +2,4 @@ aspectVersion=1.9.22.1
 wiremockTestcontainersVersion=1.0-alpha-14
 wiremockVersion=3.3.1
 testcontainersVersion=1.17.6
+googleGuavaVersion=11.0.2

--- a/KudaGo/gradle.properties
+++ b/KudaGo/gradle.properties
@@ -3,3 +3,4 @@ wiremockTestcontainersVersion=1.0-alpha-14
 wiremockVersion=3.3.1
 testcontainersVersion=1.17.6
 googleGuavaVersion=11.0.2
+swaggerVersion=2.6.0

--- a/KudaGo/gradlew.bat
+++ b/KudaGo/gradlew.bat
@@ -49,7 +49,7 @@ echo. 1>&2
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
 echo. 1>&2
 echo Please set the JAVA_HOME variable in your environment to match the 1>&2
-echo locationResponse of your Java installation. 1>&2
+echo locationDto of your Java installation. 1>&2
 
 goto fail
 
@@ -63,7 +63,7 @@ echo. 1>&2
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
 echo. 1>&2
 echo Please set the JAVA_HOME variable in your environment to match the 1>&2
-echo locationResponse of your Java installation. 1>&2
+echo locationDto of your Java installation. 1>&2
 
 goto fail
 

--- a/KudaGo/gradlew.bat
+++ b/KudaGo/gradlew.bat
@@ -49,7 +49,7 @@ echo. 1>&2
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
 echo. 1>&2
 echo Please set the JAVA_HOME variable in your environment to match the 1>&2
-echo location of your Java installation. 1>&2
+echo locationResponse of your Java installation. 1>&2
 
 goto fail
 
@@ -63,7 +63,7 @@ echo. 1>&2
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
 echo. 1>&2
 echo Please set the JAVA_HOME variable in your environment to match the 1>&2
-echo location of your Java installation. 1>&2
+echo locationResponse of your Java installation. 1>&2
 
 goto fail
 

--- a/KudaGo/src/main/java/arden/java/kudago/KudaGoApplication.java
+++ b/KudaGo/src/main/java/arden/java/kudago/KudaGoApplication.java
@@ -5,11 +5,7 @@ import arden.java.kudago.config.UrlConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-
-import java.util.concurrent.Executor;
 
 @SpringBootApplication
 @EnableConfigurationProperties({UrlConfig.class, ThreadsConfig.class})

--- a/KudaGo/src/main/java/arden/java/kudago/KudaGoApplication.java
+++ b/KudaGo/src/main/java/arden/java/kudago/KudaGoApplication.java
@@ -1,12 +1,13 @@
 package arden.java.kudago;
 
+import arden.java.kudago.config.ThreadsConfig;
 import arden.java.kudago.config.UrlConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
-@EnableConfigurationProperties({UrlConfig.class})
+@EnableConfigurationProperties({UrlConfig.class, ThreadsConfig.class})
 public class KudaGoApplication {
 
     public static void main(String[] args) {

--- a/KudaGo/src/main/java/arden/java/kudago/KudaGoApplication.java
+++ b/KudaGo/src/main/java/arden/java/kudago/KudaGoApplication.java
@@ -5,9 +5,15 @@ import arden.java.kudago.config.UrlConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
 
 @SpringBootApplication
 @EnableConfigurationProperties({UrlConfig.class, ThreadsConfig.class})
+@EnableAsync
 public class KudaGoApplication {
 
     public static void main(String[] args) {

--- a/KudaGo/src/main/java/arden/java/kudago/client/CategoryRestTemplate.java
+++ b/KudaGo/src/main/java/arden/java/kudago/client/CategoryRestTemplate.java
@@ -1,7 +1,7 @@
 package arden.java.kudago.client;
 
 import arden.java.kudago.config.UrlConfig;
-import arden.java.kudago.dto.response.places.Category;
+import arden.java.kudago.dto.response.places.CategoryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
@@ -16,8 +16,8 @@ public class CategoryRestTemplate {
     private final RestTemplate restTemplate;
     private final UrlConfig urlConfig;
 
-    public Optional<List<Category>> getAllCategories() {
-        ResponseEntity<List<Category>> response = restTemplate
+    public Optional<List<CategoryResponse>> getAllCategories() {
+        ResponseEntity<List<CategoryResponse>> response = restTemplate
                 .exchange(urlConfig.kudaGoUrl() + "/place-categories",
                         HttpMethod.GET,
                         null,

--- a/KudaGo/src/main/java/arden/java/kudago/client/CategoryRestTemplate.java
+++ b/KudaGo/src/main/java/arden/java/kudago/client/CategoryRestTemplate.java
@@ -1,7 +1,7 @@
 package arden.java.kudago.client;
 
 import arden.java.kudago.config.UrlConfig;
-import arden.java.kudago.dto.response.places.CategoryResponse;
+import arden.java.kudago.dto.response.places.CategoryDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
@@ -16,8 +16,8 @@ public class CategoryRestTemplate {
     private final RestTemplate restTemplate;
     private final UrlConfig urlConfig;
 
-    public Optional<List<CategoryResponse>> getAllCategories() {
-        ResponseEntity<List<CategoryResponse>> response = restTemplate
+    public Optional<List<CategoryDto>> getAllCategories() {
+        ResponseEntity<List<CategoryDto>> response = restTemplate
                 .exchange(urlConfig.kudaGoUrl() + "/place-categories",
                         HttpMethod.GET,
                         null,

--- a/KudaGo/src/main/java/arden/java/kudago/client/CategoryRestTemplate.java
+++ b/KudaGo/src/main/java/arden/java/kudago/client/CategoryRestTemplate.java
@@ -1,7 +1,7 @@
 package arden.java.kudago.client;
 
 import arden.java.kudago.config.UrlConfig;
-import arden.java.kudago.dto.Category;
+import arden.java.kudago.dto.response.places.Category;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
@@ -18,7 +18,7 @@ public class CategoryRestTemplate {
 
     public Optional<List<Category>> getAllCategories() {
         ResponseEntity<List<Category>> response = restTemplate
-                .exchange(urlConfig.url() + "/place-categories",
+                .exchange(urlConfig.kudaGoUrl() + "/place-categories",
                         HttpMethod.GET,
                         null,
                         new ParameterizedTypeReference<>() {

--- a/KudaGo/src/main/java/arden/java/kudago/client/CurrencyRestTemplate.java
+++ b/KudaGo/src/main/java/arden/java/kudago/client/CurrencyRestTemplate.java
@@ -1,0 +1,30 @@
+package arden.java.kudago.client;
+
+import arden.java.kudago.config.UrlConfig;
+import arden.java.kudago.dto.request.CurrencyConvertRequest;
+import arden.java.kudago.dto.response.currency.CurrencyConvertResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class CurrencyRestTemplate {
+    private final RestTemplate restTemplate;
+    private final UrlConfig urlConfig;
+
+    public Optional<Double> convertPrice(CurrencyConvertRequest currencyConvertRequest) {
+        ResponseEntity<CurrencyConvertResponse> response = restTemplate
+                .exchange(urlConfig.currencyUrl() + "/convert",
+                        HttpMethod.POST,
+                        new HttpEntity<>(currencyConvertRequest),
+                        new ParameterizedTypeReference<>() {
+                        });
+
+        return Optional.ofNullable(response.getBody().convertedAmount());
+    }
+}

--- a/KudaGo/src/main/java/arden/java/kudago/client/EventRestTemplate.java
+++ b/KudaGo/src/main/java/arden/java/kudago/client/EventRestTemplate.java
@@ -20,10 +20,10 @@ public class EventRestTemplate {
 
     public Optional<List<EventResponse>> getEvents(long start, long end) {
         String url = UriComponentsBuilder.fromHttpUrl(urlConfig.kudaGoUrl() + "/events")
-                .queryParam("expand", "locationDto")
+                .queryParam("expand", "location")
                 .queryParam("actual_since", start)
                 .queryParam("actual_until", end)
-                .queryParam("fields", "id,dates,title,slug,description,site_url,price,favorites_count,locationDto")
+                .queryParam("fields", "id,dates,title,slug,description,site_url,price,favorites_count,location")
                 .toUriString();
 
         ResponseEntity<AllEvents> response = restTemplate

--- a/KudaGo/src/main/java/arden/java/kudago/client/EventRestTemplate.java
+++ b/KudaGo/src/main/java/arden/java/kudago/client/EventRestTemplate.java
@@ -1,0 +1,38 @@
+package arden.java.kudago.client;
+
+import arden.java.kudago.config.UrlConfig;
+import arden.java.kudago.dto.response.event.AllEvents;
+import arden.java.kudago.dto.response.event.EventResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class EventRestTemplate {
+    private final RestTemplate restTemplate;
+    private final UrlConfig urlConfig;
+
+    public Optional<List<EventResponse>> getEvents(long start, long end) {
+        String url = UriComponentsBuilder.fromHttpUrl(urlConfig.kudaGoUrl() + "/events")
+                .queryParam("expand", "location")
+                .queryParam("actual_since", start)
+                .queryParam("actual_until", end)
+                .queryParam("fields", "id,dates,title,slug,description,site_url,price,favorites_count,location")
+                .toUriString();
+
+        ResponseEntity<AllEvents> response = restTemplate
+                .exchange(url,
+                        HttpMethod.GET,
+                        null,
+                        new ParameterizedTypeReference<>() {
+                        });
+
+        return Optional.ofNullable(response.getBody().eventResponses());
+    }
+}

--- a/KudaGo/src/main/java/arden/java/kudago/client/EventRestTemplate.java
+++ b/KudaGo/src/main/java/arden/java/kudago/client/EventRestTemplate.java
@@ -20,10 +20,10 @@ public class EventRestTemplate {
 
     public Optional<List<EventResponse>> getEvents(long start, long end) {
         String url = UriComponentsBuilder.fromHttpUrl(urlConfig.kudaGoUrl() + "/events")
-                .queryParam("expand", "location")
+                .queryParam("expand", "locationDto")
                 .queryParam("actual_since", start)
                 .queryParam("actual_until", end)
-                .queryParam("fields", "id,dates,title,slug,description,site_url,price,favorites_count,location")
+                .queryParam("fields", "id,dates,title,slug,description,site_url,price,favorites_count,locationDto")
                 .toUriString();
 
         ResponseEntity<AllEvents> response = restTemplate

--- a/KudaGo/src/main/java/arden/java/kudago/client/LocationRestTemplate.java
+++ b/KudaGo/src/main/java/arden/java/kudago/client/LocationRestTemplate.java
@@ -1,7 +1,7 @@
 package arden.java.kudago.client;
 
 import arden.java.kudago.config.UrlConfig;
-import arden.java.kudago.dto.Location;
+import arden.java.kudago.dto.response.places.Location;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
@@ -18,7 +18,7 @@ public class LocationRestTemplate {
 
     public Optional<List<Location>> getLocations() {
         ResponseEntity<List<Location>> response = restTemplate
-                .exchange(urlConfig.url() + "/locations",
+                .exchange(urlConfig.kudaGoUrl() + "/locations",
                         HttpMethod.GET,
                         null,
                         new ParameterizedTypeReference<>() {

--- a/KudaGo/src/main/java/arden/java/kudago/client/LocationRestTemplate.java
+++ b/KudaGo/src/main/java/arden/java/kudago/client/LocationRestTemplate.java
@@ -1,7 +1,7 @@
 package arden.java.kudago.client;
 
 import arden.java.kudago.config.UrlConfig;
-import arden.java.kudago.dto.response.places.Location;
+import arden.java.kudago.dto.response.places.LocationResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
@@ -16,8 +16,8 @@ public class LocationRestTemplate {
     private final RestTemplate restTemplate;
     private final UrlConfig urlConfig;
 
-    public Optional<List<Location>> getLocations() {
-        ResponseEntity<List<Location>> response = restTemplate
+    public Optional<List<LocationResponse>> getLocations() {
+        ResponseEntity<List<LocationResponse>> response = restTemplate
                 .exchange(urlConfig.kudaGoUrl() + "/locations",
                         HttpMethod.GET,
                         null,

--- a/KudaGo/src/main/java/arden/java/kudago/client/LocationRestTemplate.java
+++ b/KudaGo/src/main/java/arden/java/kudago/client/LocationRestTemplate.java
@@ -1,7 +1,7 @@
 package arden.java.kudago.client;
 
 import arden.java.kudago.config.UrlConfig;
-import arden.java.kudago.dto.response.places.LocationResponse;
+import arden.java.kudago.dto.response.places.LocationDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
@@ -16,8 +16,8 @@ public class LocationRestTemplate {
     private final RestTemplate restTemplate;
     private final UrlConfig urlConfig;
 
-    public Optional<List<LocationResponse>> getLocations() {
-        ResponseEntity<List<LocationResponse>> response = restTemplate
+    public Optional<List<LocationDto>> getLocations() {
+        ResponseEntity<List<LocationDto>> response = restTemplate
                 .exchange(urlConfig.kudaGoUrl() + "/locations",
                         HttpMethod.GET,
                         null,

--- a/KudaGo/src/main/java/arden/java/kudago/config/ClientConfiguration.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/ClientConfiguration.java
@@ -1,6 +1,8 @@
 package arden.java.kudago.config;
 
 import arden.java.kudago.client.CategoryRestTemplate;
+import arden.java.kudago.client.CurrencyRestTemplate;
+import arden.java.kudago.client.EventRestTemplate;
 import arden.java.kudago.client.LocationRestTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -21,5 +23,15 @@ public class ClientConfiguration {
     @Bean
     public LocationRestTemplate locationRestTemplate() {
         return new LocationRestTemplate(restTemplate, urlConfig);
+    }
+
+    @Bean
+    public CurrencyRestTemplate currencyRestTemplate() {
+        return new CurrencyRestTemplate(restTemplate, urlConfig);
+    }
+
+    @Bean
+    public EventRestTemplate eventRestTemplate() {
+        return new EventRestTemplate(restTemplate, urlConfig);
     }
 }

--- a/KudaGo/src/main/java/arden/java/kudago/config/RepositoryConfiguration.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/RepositoryConfiguration.java
@@ -1,7 +1,6 @@
 package arden.java.kudago.config;
 
-import arden.java.kudago.dto.response.places.CategoryResponse;
-import arden.java.kudago.dto.response.places.LocationResponse;
+import arden.java.kudago.dto.response.places.CategoryDto;
 import arden.java.kudago.repository.StorageRepository;
 import arden.java.kudago.repository.impl.StorageRepositoryImpl;
 import org.springframework.context.annotation.Bean;
@@ -10,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RepositoryConfiguration {
     @Bean
-    public StorageRepository<Long, CategoryResponse> categoryRepository() {
+    public StorageRepository<Long, CategoryDto> categoryRepository() {
         return new StorageRepositoryImpl<>();
     }
 }

--- a/KudaGo/src/main/java/arden/java/kudago/config/RepositoryConfiguration.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/RepositoryConfiguration.java
@@ -1,7 +1,7 @@
 package arden.java.kudago.config;
 
-import arden.java.kudago.dto.Category;
-import arden.java.kudago.dto.Location;
+import arden.java.kudago.dto.response.places.Category;
+import arden.java.kudago.dto.response.places.Location;
 import arden.java.kudago.repository.StorageRepository;
 import arden.java.kudago.repository.impl.StorageRepositoryImpl;
 import org.springframework.context.annotation.Bean;

--- a/KudaGo/src/main/java/arden/java/kudago/config/RepositoryConfiguration.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/RepositoryConfiguration.java
@@ -1,7 +1,7 @@
 package arden.java.kudago.config;
 
-import arden.java.kudago.dto.response.places.Category;
-import arden.java.kudago.dto.response.places.Location;
+import arden.java.kudago.dto.response.places.CategoryResponse;
+import arden.java.kudago.dto.response.places.LocationResponse;
 import arden.java.kudago.repository.StorageRepository;
 import arden.java.kudago.repository.impl.StorageRepositoryImpl;
 import org.springframework.context.annotation.Bean;
@@ -10,12 +10,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RepositoryConfiguration {
     @Bean
-    public StorageRepository<Long, Category> categoryRepository() {
-        return new StorageRepositoryImpl<>();
-    }
-
-    @Bean
-    public StorageRepository<String, Location> locationRepository() {
+    public StorageRepository<Long, CategoryResponse> categoryRepository() {
         return new StorageRepositoryImpl<>();
     }
 }

--- a/KudaGo/src/main/java/arden/java/kudago/config/SpecificationConfig.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/SpecificationConfig.java
@@ -1,0 +1,18 @@
+package arden.java.kudago.config;
+
+import net.kaczmarzyk.spring.data.jpa.web.SpecificationArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class SpecificationConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(new SpecificationArgumentResolver());
+    }
+
+}

--- a/KudaGo/src/main/java/arden/java/kudago/config/ThreadPoolConfiguration.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/ThreadPoolConfiguration.java
@@ -4,12 +4,10 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.time.Duration;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.*;
 
 @Configuration
 @RequiredArgsConstructor
@@ -42,5 +40,13 @@ public class ThreadPoolConfiguration {
     @Bean
     public Duration delay() {
         return Duration.ofSeconds(threadsConfig.delayInSeconds());
+    }
+
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setThreadNamePrefix("SuitableEvents-");
+        executor.initialize();
+        return executor;
     }
 }

--- a/KudaGo/src/main/java/arden/java/kudago/config/ThreadPoolConfiguration.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/ThreadPoolConfiguration.java
@@ -49,4 +49,9 @@ public class ThreadPoolConfiguration {
         executor.initialize();
         return executor;
     }
+
+    @Bean
+    public Semaphore semaphore() {
+        return new Semaphore(threadsConfig.maxNumOfThreads());
+    }
 }

--- a/KudaGo/src/main/java/arden/java/kudago/config/ThreadPoolConfiguration.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/ThreadPoolConfiguration.java
@@ -20,7 +20,7 @@ public class ThreadPoolConfiguration {
                 .setNameFormat("Data-processor-%d")
                 .build();
 
-        return Executors.newFixedThreadPool(threadsConfig.fixedPoolSize(), threadFactory);
+        return Executors.newFixedThreadPool(threadsConfig.threadsNum(), threadFactory);
     }
 
     @Bean
@@ -29,7 +29,7 @@ public class ThreadPoolConfiguration {
                 .setNameFormat("Scheduler-%d")
                 .build();
 
-        return Executors.newScheduledThreadPool(threadsConfig.scheduledPoolSize(), threadFactory);
+        return Executors.newScheduledThreadPool(threadsConfig.threadsNum(), threadFactory);
     }
 
     @Bean

--- a/KudaGo/src/main/java/arden/java/kudago/config/ThreadPoolConfiguration.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/ThreadPoolConfiguration.java
@@ -1,0 +1,46 @@
+package arden.java.kudago.config;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+
+@Configuration
+@RequiredArgsConstructor
+public class ThreadPoolConfiguration {
+    private final ThreadsConfig threadsConfig;
+
+    @Bean
+    public ExecutorService fixedThreadPool() {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("Data-processor-%d")
+                .build();
+
+        return Executors.newFixedThreadPool(threadsConfig.fixedPoolSize(), threadFactory);
+    }
+
+    @Bean
+    public ScheduledExecutorService scheduledThreadPool() {
+        ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("Scheduler-%d")
+                .build();
+
+        return Executors.newScheduledThreadPool(threadsConfig.scheduledPoolSize(), threadFactory);
+    }
+
+    @Bean
+    public Duration period() {
+        return Duration.ofSeconds(threadsConfig.periodInSeconds());
+    }
+
+    @Bean
+    public Duration delay() {
+        return Duration.ofSeconds(threadsConfig.delayInSeconds());
+    }
+}

--- a/KudaGo/src/main/java/arden/java/kudago/config/ThreadPoolConfiguration.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/ThreadPoolConfiguration.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import java.time.Duration;
 import java.util.concurrent.*;
 
 @Configuration
@@ -30,16 +29,6 @@ public class ThreadPoolConfiguration {
                 .build();
 
         return Executors.newScheduledThreadPool(threadsConfig.threadsNum(), threadFactory);
-    }
-
-    @Bean
-    public Duration period() {
-        return Duration.ofSeconds(threadsConfig.periodInSeconds());
-    }
-
-    @Bean
-    public Duration delay() {
-        return Duration.ofSeconds(threadsConfig.delayInSeconds());
     }
 
     @Bean

--- a/KudaGo/src/main/java/arden/java/kudago/config/ThreadsConfig.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/ThreadsConfig.java
@@ -6,9 +6,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "multithreading")
 public record ThreadsConfig(
         @NonNull
-        Integer fixedPoolSize,
-        @NonNull
-        Integer scheduledPoolSize,
+        Integer threadsNum,
         @NonNull
         Long periodInSeconds,
         @NonNull

--- a/KudaGo/src/main/java/arden/java/kudago/config/ThreadsConfig.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/ThreadsConfig.java
@@ -3,14 +3,16 @@ package arden.java.kudago.config;
 import lombok.NonNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 @ConfigurationProperties(prefix = "multithreading")
 public record ThreadsConfig(
         @NonNull
         Integer threadsNum,
         @NonNull
-        Long periodInSeconds,
+        Duration periodInSeconds,
         @NonNull
-        Long delayInSeconds,
+        Duration delayInSeconds,
         @NonNull
         Integer maxNumOfThreads
 ) {

--- a/KudaGo/src/main/java/arden/java/kudago/config/ThreadsConfig.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/ThreadsConfig.java
@@ -1,0 +1,17 @@
+package arden.java.kudago.config;
+
+import lombok.NonNull;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "multithreading")
+public record ThreadsConfig(
+        @NonNull
+        Integer fixedPoolSize,
+        @NonNull
+        Integer scheduledPoolSize,
+        @NonNull
+        Long periodInSeconds,
+        @NonNull
+        Long delayInSeconds
+) {
+}

--- a/KudaGo/src/main/java/arden/java/kudago/config/ThreadsConfig.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/ThreadsConfig.java
@@ -12,6 +12,8 @@ public record ThreadsConfig(
         @NonNull
         Long periodInSeconds,
         @NonNull
-        Long delayInSeconds
+        Long delayInSeconds,
+        @NonNull
+        Integer maxNumOfThreads
 ) {
 }

--- a/KudaGo/src/main/java/arden/java/kudago/config/UrlConfig.java
+++ b/KudaGo/src/main/java/arden/java/kudago/config/UrlConfig.java
@@ -2,12 +2,12 @@ package arden.java.kudago.config;
 
 import lombok.NonNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.validation.annotation.Validated;
 
-@Validated
 @ConfigurationProperties(prefix = "base-config")
 public record UrlConfig(
         @NonNull
-        String url
+        String kudaGoUrl,
+        @NonNull
+        String currencyUrl
 ) {
 }

--- a/KudaGo/src/main/java/arden/java/kudago/controller/CategoryController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/CategoryController.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.Category;
+import arden.java.kudago.dto.response.places.Category;
 import arden.java.kudago.service.CategoryService;
 import configuration.annotation.logtimexec.LogTimeExec;
 import lombok.RequiredArgsConstructor;

--- a/KudaGo/src/main/java/arden/java/kudago/controller/CategoryController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/CategoryController.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.response.places.Category;
+import arden.java.kudago.dto.response.places.CategoryResponse;
 import arden.java.kudago.service.CategoryService;
 import configuration.annotation.logtimexec.LogTimeExec;
 import lombok.RequiredArgsConstructor;
@@ -17,23 +17,23 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @GetMapping
-    public ResponseEntity<List<Category>> getCategories() {
+    public ResponseEntity<List<CategoryResponse>> getCategories() {
         return ResponseEntity.ok(categoryService.getAllCategories());
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Category> getCategory(@PathVariable Long id) {
+    public ResponseEntity<CategoryResponse> getCategory(@PathVariable Long id) {
         return ResponseEntity.ok(categoryService.getCategoryById(id));
     }
 
     @PostMapping
-    public ResponseEntity<Category> createCategory(@RequestBody Category category) {
-        return ResponseEntity.ok(categoryService.createCategory(category));
+    public ResponseEntity<CategoryResponse> createCategory(@RequestBody CategoryResponse categoryResponse) {
+        return ResponseEntity.ok(categoryService.createCategory(categoryResponse));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Category> updateCategory(@PathVariable Long id, @RequestBody Category category) {
-        return ResponseEntity.ok(categoryService.updateCategory(id, category));
+    public ResponseEntity<CategoryResponse> updateCategory(@PathVariable Long id, @RequestBody CategoryResponse categoryResponse) {
+        return ResponseEntity.ok(categoryService.updateCategory(id, categoryResponse));
     }
 
     @DeleteMapping("/{id}")

--- a/KudaGo/src/main/java/arden/java/kudago/controller/CategoryController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/CategoryController.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.response.places.CategoryResponse;
+import arden.java.kudago.dto.response.places.CategoryDto;
 import arden.java.kudago.service.CategoryService;
 import configuration.annotation.logtimexec.LogTimeExec;
 import lombok.RequiredArgsConstructor;
@@ -17,23 +17,23 @@ public class CategoryController {
     private final CategoryService categoryService;
 
     @GetMapping
-    public ResponseEntity<List<CategoryResponse>> getCategories() {
+    public ResponseEntity<List<CategoryDto>> getCategories() {
         return ResponseEntity.ok(categoryService.getAllCategories());
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<CategoryResponse> getCategory(@PathVariable Long id) {
+    public ResponseEntity<CategoryDto> getCategory(@PathVariable Long id) {
         return ResponseEntity.ok(categoryService.getCategoryById(id));
     }
 
     @PostMapping
-    public ResponseEntity<CategoryResponse> createCategory(@RequestBody CategoryResponse categoryResponse) {
-        return ResponseEntity.ok(categoryService.createCategory(categoryResponse));
+    public ResponseEntity<CategoryDto> createCategory(@RequestBody CategoryDto categoryDto) {
+        return ResponseEntity.ok(categoryService.createCategory(categoryDto));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<CategoryResponse> updateCategory(@PathVariable Long id, @RequestBody CategoryResponse categoryResponse) {
-        return ResponseEntity.ok(categoryService.updateCategory(id, categoryResponse));
+    public ResponseEntity<CategoryDto> updateCategory(@PathVariable Long id, @RequestBody CategoryDto categoryDto) {
+        return ResponseEntity.ok(categoryService.updateCategory(id, categoryDto));
     }
 
     @DeleteMapping("/{id}")

--- a/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
@@ -8,6 +8,8 @@ import arden.java.kudago.service.SuitableEventService;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -42,8 +44,9 @@ public class EventController {
     }
 
     @GetMapping("/list")
-    public ResponseEntity<List<EventDto>> getAllEvents() {
-        return ResponseEntity.ok(eventService.getAllEvents());
+    public ResponseEntity<Page<EventDto>> getAllEvents(@RequestParam(defaultValue = "0") int page,
+                                                       @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(eventService.getAllEvents(PageRequest.of(page, size)));
     }
 
     @GetMapping("/filter")

--- a/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
@@ -26,7 +26,7 @@ public class EventController {
 
     @Validated
     @GetMapping("/events")
-    public ResponseEntity<List<Event>> getSuitableEvents(@RequestParam @Min(value = 0, message = "Ваш бюджет должен быть неотрицательным числом")
+    public ResponseEntity<Mono<List<Event>>> getSuitableEvents(@RequestParam @Min(value = 0, message = "Ваш бюджет должен быть неотрицательным числом")
                                                          Double budget,
 
                                                          @RequestParam @NotNull(message = "Укажите валюту для конвертации")
@@ -37,6 +37,6 @@ public class EventController {
 
                                                          @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd")
                                                          LocalDate dateTo) {
-        return ResponseEntity.ok(eventService.getSuitableEvents(budget, currency, dateFrom, dateTo).block());
+        return ResponseEntity.ok(eventService.getSuitableEvents(budget, currency, dateFrom, dateTo));
     }
 }

--- a/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
@@ -1,42 +1,77 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.response.event.Event;
+import arden.java.kudago.dto.response.event.EventDto;
+import arden.java.kudago.dto.response.event.SuitableEvent;
 import arden.java.kudago.dto.response.event.EventResponse;
 import arden.java.kudago.service.EventService;
+import arden.java.kudago.service.SuitableEventService;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/events")
 @RequiredArgsConstructor
 public class EventController {
-    private final EventService<Mono<List<EventResponse>>, Mono<List<Event>>> eventService;
-
+    private final SuitableEventService<Mono<List<EventResponse>>, Mono<List<SuitableEvent>>> suitableEventService;
+    private final EventService eventService;
+    
     @Validated
-    @GetMapping("/events")
-    public ResponseEntity<List<Event>> getSuitableEvents(@RequestParam @Min(value = 0, message = "Ваш бюджет должен быть неотрицательным числом")
+    @GetMapping("/suitable")
+    public ResponseEntity<List<SuitableEvent>> getSuitableEvents(@RequestParam @Min(value = 0, message = "Ваш бюджет должен быть неотрицательным числом")
                                                          Double budget,
 
-                                                         @RequestParam @NotNull(message = "Укажите валюту для конвертации")
+                                                                 @RequestParam @NotNull(message = "Укажите валюту для конвертации")
                                                          String currency,
 
-                                                         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd")
+                                                                 @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd")
                                                          LocalDate dateFrom,
 
-                                                         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd")
+                                                                 @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd")
                                                          LocalDate dateTo) {
-        return ResponseEntity.ok(eventService.getSuitableEvents(budget, currency, dateFrom, dateTo).block());
+        return ResponseEntity.ok(suitableEventService.getSuitableEvents(budget, currency, dateFrom, dateTo).block());
+    }
+
+    @GetMapping("/list")
+    public ResponseEntity<List<EventDto>> getAllEvents() {
+        return ResponseEntity.ok(eventService.getAllEvents());
+    }
+
+    @GetMapping("/filter")
+    public ResponseEntity<List<EventDto>> getAllEventsByFilter(@RequestParam(required = false) String name,
+                                                               @RequestParam(required = false) String location,
+                                                               @RequestParam(required = false) OffsetDateTime fromDate,
+                                                               @RequestParam(required = false) OffsetDateTime toDate) {
+        return ResponseEntity.ok(eventService.getEventsByFilter(name, location, fromDate, toDate));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<EventDto> getEvent(@PathVariable Long id) {
+        return ResponseEntity.ok(eventService.getEventById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<EventDto> createEvent(@RequestBody EventDto EventDto) {
+        return ResponseEntity.ok(eventService.createEvent(EventDto));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<EventDto> updateCategory(@PathVariable Long id, @RequestBody EventDto EventDto) {
+        return ResponseEntity.ok(eventService.updateEvent(id, EventDto));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Boolean> deleteEvent(@PathVariable Long id) {
+        eventService.deleteEvent(id);
+        return ResponseEntity.ok(true);
     }
 }

--- a/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
@@ -1,6 +1,7 @@
 package arden.java.kudago.controller;
 
 import arden.java.kudago.dto.response.event.Event;
+import arden.java.kudago.dto.response.event.EventResponse;
 import arden.java.kudago.service.EventService;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -20,7 +22,7 @@ import java.util.List;
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class EventController {
-    private final EventService eventService;
+    private final EventService<Mono<List<EventResponse>>, Mono<List<Event>>> eventService;
 
     @Validated
     @GetMapping("/events")
@@ -35,6 +37,6 @@ public class EventController {
 
                                                          @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd")
                                                          LocalDate dateTo) {
-        return ResponseEntity.ok(eventService.getSuitableEvents(budget, currency, dateFrom, dateTo).join());
+        return ResponseEntity.ok(eventService.getSuitableEvents(budget, currency, dateFrom, dateTo).block());
     }
 }

--- a/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
@@ -1,21 +1,16 @@
 package arden.java.kudago.controller;
 
 import arden.java.kudago.dto.response.event.EventDto;
-import arden.java.kudago.dto.response.event.SuitableEvent;
 import arden.java.kudago.dto.response.event.EventResponse;
-import arden.java.kudago.model.Event;
+import arden.java.kudago.dto.response.event.SuitableEvent;
 import arden.java.kudago.model.specification.EventSpecification;
 import arden.java.kudago.service.EventService;
 import arden.java.kudago.service.SuitableEventService;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import net.kaczmarzyk.spring.data.jpa.domain.Between;
-import net.kaczmarzyk.spring.data.jpa.domain.Equal;
-import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -23,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
 import java.util.List;
 
 @RestController
@@ -32,20 +26,20 @@ import java.util.List;
 public class EventController {
     private final SuitableEventService<Mono<List<EventResponse>>, Mono<List<SuitableEvent>>> suitableEventService;
     private final EventService eventService;
-    
+
     @Validated
     @GetMapping("/suitable")
     public ResponseEntity<List<SuitableEvent>> getSuitableEvents(@RequestParam @Min(value = 0, message = "Ваш бюджет должен быть неотрицательным числом")
-                                                         Double budget,
+                                                                 Double budget,
 
                                                                  @RequestParam @NotNull(message = "Укажите валюту для конвертации")
-                                                         String currency,
+                                                                 String currency,
 
                                                                  @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd")
-                                                         LocalDate dateFrom,
+                                                                 LocalDate dateFrom,
 
                                                                  @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd")
-                                                         LocalDate dateTo) {
+                                                                 LocalDate dateTo) {
         return ResponseEntity.ok(suitableEventService.getSuitableEvents(budget, currency, dateFrom, dateTo).block());
     }
 

--- a/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
@@ -1,0 +1,40 @@
+package arden.java.kudago.controller;
+
+import arden.java.kudago.dto.response.event.Event;
+import arden.java.kudago.service.EventService;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class EventController {
+    private final EventService eventService;
+
+    @Validated
+    @GetMapping("/events")
+    public ResponseEntity<List<Event>> getSuitableEvents(@RequestParam @Min(value = 0, message = "Ваш бюджет должен быть неотрицательным числом")
+                                                         Double budget,
+
+                                                         @RequestParam @NotNull(message = "Укажите валюту для конвертации")
+                                                         String currency,
+
+                                                         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd")
+                                                         LocalDate dateFrom,
+
+                                                         @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd")
+                                                         LocalDate dateTo) {
+        return ResponseEntity.ok(eventService.getSuitableEvents(budget, currency, dateFrom, dateTo).join());
+    }
+}

--- a/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/EventController.java
@@ -3,13 +3,19 @@ package arden.java.kudago.controller;
 import arden.java.kudago.dto.response.event.EventDto;
 import arden.java.kudago.dto.response.event.SuitableEvent;
 import arden.java.kudago.dto.response.event.EventResponse;
+import arden.java.kudago.model.Event;
+import arden.java.kudago.model.specification.EventSpecification;
 import arden.java.kudago.service.EventService;
 import arden.java.kudago.service.SuitableEventService;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import net.kaczmarzyk.spring.data.jpa.domain.Between;
+import net.kaczmarzyk.spring.data.jpa.domain.Equal;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -50,11 +56,10 @@ public class EventController {
     }
 
     @GetMapping("/filter")
-    public ResponseEntity<List<EventDto>> getAllEventsByFilter(@RequestParam(required = false) String name,
-                                                               @RequestParam(required = false) String location,
-                                                               @RequestParam(required = false) OffsetDateTime fromDate,
-                                                               @RequestParam(required = false) OffsetDateTime toDate) {
-        return ResponseEntity.ok(eventService.getEventsByFilter(name, location, fromDate, toDate));
+    public ResponseEntity<Page<EventDto>> getAllEventsByFilter(EventSpecification eventSpecification,
+                                                               @RequestParam(defaultValue = "0") int page,
+                                                               @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(eventService.getEventsByFilter(eventSpecification, PageRequest.of(page, size)));
     }
 
     @GetMapping("/{id}")

--- a/KudaGo/src/main/java/arden/java/kudago/controller/LocationController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/LocationController.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.response.places.LocationResponse;
+import arden.java.kudago.dto.response.places.LocationDto;
 import arden.java.kudago.service.LocationService;
 import configuration.annotation.logtimexec.LogTimeExec;
 import lombok.RequiredArgsConstructor;
@@ -17,23 +17,23 @@ public class LocationController {
     private final LocationService locationService;
 
     @GetMapping
-    public ResponseEntity<List<LocationResponse>> getAllLocations() {
+    public ResponseEntity<List<LocationDto>> getAllLocations() {
         return ResponseEntity.ok(locationService.getAllLocations());
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<LocationResponse> getLocation(@PathVariable Long id) {
+    public ResponseEntity<LocationDto> getLocation(@PathVariable Long id) {
         return ResponseEntity.ok(locationService.getLocationById(id));
     }
 
     @PostMapping
-    public ResponseEntity<LocationResponse> createLocation(@RequestBody LocationResponse locationResponse) {
-        return ResponseEntity.ok(locationService.createLocation(locationResponse));
+    public ResponseEntity<LocationDto> createLocation(@RequestBody LocationDto locationDto) {
+        return ResponseEntity.ok(locationService.createLocation(locationDto));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<LocationResponse> updateCategory(@PathVariable Long id, @RequestBody LocationResponse locationResponse) {
-        return ResponseEntity.ok(locationService.updateLocation(id, locationResponse));
+    public ResponseEntity<LocationDto> updateLocation(@PathVariable Long id, @RequestBody LocationDto locationDto) {
+        return ResponseEntity.ok(locationService.updateLocation(id, locationDto));
     }
 
     @DeleteMapping("/{id}")

--- a/KudaGo/src/main/java/arden/java/kudago/controller/LocationController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/LocationController.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.Location;
+import arden.java.kudago.dto.response.places.Location;
 import arden.java.kudago.service.LocationService;
 import configuration.annotation.logtimexec.LogTimeExec;
 import lombok.RequiredArgsConstructor;

--- a/KudaGo/src/main/java/arden/java/kudago/controller/LocationController.java
+++ b/KudaGo/src/main/java/arden/java/kudago/controller/LocationController.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.response.places.Location;
+import arden.java.kudago.dto.response.places.LocationResponse;
 import arden.java.kudago.service.LocationService;
 import configuration.annotation.logtimexec.LogTimeExec;
 import lombok.RequiredArgsConstructor;
@@ -17,27 +17,28 @@ public class LocationController {
     private final LocationService locationService;
 
     @GetMapping
-    public ResponseEntity<List<Location>> getAllLocations() {
+    public ResponseEntity<List<LocationResponse>> getAllLocations() {
         return ResponseEntity.ok(locationService.getAllLocations());
     }
 
-    @GetMapping("/{slug}")
-    public ResponseEntity<Location> getLocation(@PathVariable String slug) {
-        return ResponseEntity.ok(locationService.getLocationBySlug(slug));
+    @GetMapping("/{id}")
+    public ResponseEntity<LocationResponse> getLocation(@PathVariable Long id) {
+        return ResponseEntity.ok(locationService.getLocationById(id));
     }
 
     @PostMapping
-    public ResponseEntity<Location> createLocation(@RequestBody Location location) {
-        return ResponseEntity.ok(locationService.createLocation(location));
+    public ResponseEntity<LocationResponse> createLocation(@RequestBody LocationResponse locationResponse) {
+        return ResponseEntity.ok(locationService.createLocation(locationResponse));
     }
 
-    @PutMapping("/{slug}")
-    public ResponseEntity<Location> updateCategory(@PathVariable String slug, @RequestBody Location location) {
-        return ResponseEntity.ok(locationService.updateLocation(slug, location));
+    @PutMapping("/{id}")
+    public ResponseEntity<LocationResponse> updateCategory(@PathVariable Long id, @RequestBody LocationResponse locationResponse) {
+        return ResponseEntity.ok(locationService.updateLocation(id, locationResponse));
     }
 
-    @DeleteMapping("/{slug}")
-    public ResponseEntity<Boolean> deleteLocation(@PathVariable String slug) {
-        return ResponseEntity.ok(locationService.deleteLocation(slug));
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Boolean> deleteLocation(@PathVariable Long id) {
+        locationService.deleteLocation(id);
+        return ResponseEntity.ok(true);
     }
 }

--- a/KudaGo/src/main/java/arden/java/kudago/dto/request/CurrencyConvertRequest.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/request/CurrencyConvertRequest.java
@@ -1,0 +1,18 @@
+package arden.java.kudago.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record CurrencyConvertRequest(
+        @NotBlank(message = "Исходная валюта для конвертации не указана")
+        String fromCurrency,
+
+        @NotBlank(message = "Целевая валюта для конвертации не указана")
+        String toCurrency,
+
+        @Min(value = 0, message = "Количество валюты для конвертации должно быть неотрицательным числом")
+        Double amount
+) {
+}

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/currency/CurrencyConvertResponse.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/currency/CurrencyConvertResponse.java
@@ -1,0 +1,8 @@
+package arden.java.kudago.dto.response.currency;
+
+public record CurrencyConvertResponse(
+        String fromCurrency,
+        String toCurrency,
+        Double convertedAmount
+) {
+}

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/event/AllEvents.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/event/AllEvents.java
@@ -1,0 +1,11 @@
+package arden.java.kudago.dto.response.event;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record AllEvents(
+        @JsonProperty("results")
+        List<EventResponse> eventResponses
+) {
+}

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/event/Event.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/event/Event.java
@@ -1,0 +1,24 @@
+package arden.java.kudago.dto.response.event;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record Event(
+        Long id,
+        List<ConvertedDates> dates,
+        String title,
+        String description,
+        String siteUrl,
+        String price,
+        Long favoritesCount
+) {
+    @Builder
+    public record ConvertedDates(
+            LocalDate start,
+            LocalDate end
+    ) {
+    }
+}

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/event/EventDto.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/event/EventDto.java
@@ -1,6 +1,5 @@
 package arden.java.kudago.dto.response.event;
 
-import arden.java.kudago.model.Location;
 import lombok.Builder;
 
 import java.time.OffsetDateTime;
@@ -9,6 +8,6 @@ import java.time.OffsetDateTime;
 public record EventDto(
         String name,
         OffsetDateTime date,
-        Location location
+        Long locationId
 ) {
 }

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/event/EventDto.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/event/EventDto.java
@@ -1,0 +1,14 @@
+package arden.java.kudago.dto.response.event;
+
+import arden.java.kudago.model.Location;
+import lombok.Builder;
+
+import java.time.OffsetDateTime;
+
+@Builder
+public record EventDto(
+        String name,
+        OffsetDateTime date,
+        Location location
+) {
+}

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/event/EventResponse.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/event/EventResponse.java
@@ -1,0 +1,24 @@
+package arden.java.kudago.dto.response.event;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record EventResponse(Long id,
+                            List<Dates> dates,
+                            String title,
+                            String description,
+                            @JsonProperty("site_url")
+                           String siteUrl,
+                            String price,
+                            @JsonProperty("favorites_count")
+                           Long favoritesCount) {
+
+    public record Dates(
+            Long start,
+            Long end
+    ) {
+    }
+}

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/event/SuitableEvent.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/event/SuitableEvent.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Builder
-public record Event(
+public record SuitableEvent(
         Long id,
         List<ConvertedDates> dates,
         String title,

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/places/Category.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/places/Category.java
@@ -1,4 +1,4 @@
-package arden.java.kudago.dto;
+package arden.java.kudago.dto.response.places;
 
 public record Category(
         Long id,

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/places/CategoryDto.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/places/CategoryDto.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.dto.response.places;
 
-public record CategoryResponse(
+public record CategoryDto(
         Long id,
         String slug,
         String name

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/places/CategoryResponse.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/places/CategoryResponse.java
@@ -1,7 +1,7 @@
 package arden.java.kudago.dto.response.places;
 
-public record Location(
+public record CategoryResponse(
+        Long id,
         String slug,
         String name
-) {
-}
+) {}

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/places/Location.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/places/Location.java
@@ -1,4 +1,4 @@
-package arden.java.kudago.dto;
+package arden.java.kudago.dto.response.places;
 
 public record Location(
         String slug,

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/places/LocationDto.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/places/LocationDto.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.dto.response.places;
 
-public record LocationResponse(
+public record LocationDto(
         String slug,
         String name
 ) {

--- a/KudaGo/src/main/java/arden/java/kudago/dto/response/places/LocationResponse.java
+++ b/KudaGo/src/main/java/arden/java/kudago/dto/response/places/LocationResponse.java
@@ -1,7 +1,7 @@
 package arden.java.kudago.dto.response.places;
 
-public record Category(
-        Long id,
+public record LocationResponse(
         String slug,
         String name
-) {}
+) {
+}

--- a/KudaGo/src/main/java/arden/java/kudago/event/StartupLogic.java
+++ b/KudaGo/src/main/java/arden/java/kudago/event/StartupLogic.java
@@ -2,6 +2,7 @@ package arden.java.kudago.event;
 
 import arden.java.kudago.client.CategoryRestTemplate;
 import arden.java.kudago.client.LocationRestTemplate;
+import arden.java.kudago.config.ThreadsConfig;
 import arden.java.kudago.dto.response.places.Category;
 import arden.java.kudago.dto.response.places.Location;
 import arden.java.kudago.exception.GeneralException;
@@ -19,7 +20,6 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -40,8 +40,7 @@ public class StartupLogic implements ApplicationContextAware {
     private final ExecutorService fixedThreadPool;
     @Qualifier("scheduledThreadPool")
     private final ScheduledExecutorService scheduledExecutorService;
-    private final Duration period;
-    private final Duration delay;
+    private final ThreadsConfig threadsConfig;
     private ApplicationContext applicationContext;
 
     @Override
@@ -52,7 +51,7 @@ public class StartupLogic implements ApplicationContextAware {
     @EventListener(ApplicationReadyEvent.class)
     public void startup() {
         log.info("Starting up, preparing to initialize DB with data");
-        scheduledExecutorService.scheduleAtFixedRate(this::fillDB, delay.toSeconds(), period.toSeconds(), TimeUnit.SECONDS);
+        scheduledExecutorService.scheduleAtFixedRate(this::fillDB, threadsConfig.delayInSeconds().toSeconds(), threadsConfig.periodInSeconds().toSeconds(), TimeUnit.SECONDS);
     }
 
     public void fillDB() {

--- a/KudaGo/src/main/java/arden/java/kudago/event/StartupLogic.java
+++ b/KudaGo/src/main/java/arden/java/kudago/event/StartupLogic.java
@@ -2,16 +2,16 @@ package arden.java.kudago.event;
 
 import arden.java.kudago.client.CategoryRestTemplate;
 import arden.java.kudago.client.LocationRestTemplate;
-import arden.java.kudago.dto.Category;
-import arden.java.kudago.dto.Location;
+import arden.java.kudago.dto.response.places.Category;
+import arden.java.kudago.dto.response.places.Location;
 import arden.java.kudago.exception.GeneralException;
 import arden.java.kudago.repository.StorageRepository;
 import configuration.annotation.logtimexec.LogTimeExec;
 import jakarta.annotation.PreDestroy;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationContext;
@@ -29,13 +29,16 @@ import java.util.concurrent.TimeUnit;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 @LogTimeExec
 public class StartupLogic implements ApplicationContextAware {
     private final CategoryRestTemplate categoryRestTemplate;
     private final LocationRestTemplate locationRestTemplate;
     private final StorageRepository<Long, Category> categoryRepository;
     private final StorageRepository<String, Location> locationStorage;
+    @Qualifier("fixedThreadPool")
     private final ExecutorService fixedThreadPool;
+    @Qualifier("scheduledThreadPool")
     private final ScheduledExecutorService scheduledExecutorService;
     private final Duration period;
     private final Duration delay;
@@ -44,25 +47,6 @@ public class StartupLogic implements ApplicationContextAware {
     @Override
     public void setApplicationContext(@NonNull ApplicationContext applicationContext) throws BeansException {
         this.applicationContext = applicationContext;
-    }
-
-    @Autowired
-    public StartupLogic(CategoryRestTemplate categoryRestTemplate,
-                        LocationRestTemplate locationRestTemplate,
-                        StorageRepository<Long, Category> categoryRepository,
-                        StorageRepository<String, Location> locationStorage,
-                        Duration period,
-                        Duration delay,
-                        @Qualifier("fixedThreadPool") ExecutorService fixedThreadPool,
-                        @Qualifier("scheduledThreadPool") ScheduledExecutorService scheduledExecutorService) {
-        this.categoryRestTemplate = categoryRestTemplate;
-        this.locationRestTemplate = locationRestTemplate;
-        this.categoryRepository = categoryRepository;
-        this.locationStorage = locationStorage;
-        this.fixedThreadPool = fixedThreadPool;
-        this.scheduledExecutorService = scheduledExecutorService;
-        this.period = period;
-        this.delay = delay;
     }
 
     @EventListener(ApplicationReadyEvent.class)
@@ -96,7 +80,7 @@ public class StartupLogic implements ApplicationContextAware {
 
             return categories.toString();
         } else {
-            log.info("Problems with saving categories to DB");
+            log.error("Problems with saving categories to DB");
             throw new GeneralException("Categories were not found");
         }
     }

--- a/KudaGo/src/main/java/arden/java/kudago/model/Event.java
+++ b/KudaGo/src/main/java/arden/java/kudago/model/Event.java
@@ -1,0 +1,28 @@
+package arden.java.kudago.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "events")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Event {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private OffsetDateTime date;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", referencedColumnName = "id")
+    private Location location;
+}

--- a/KudaGo/src/main/java/arden/java/kudago/model/Location.java
+++ b/KudaGo/src/main/java/arden/java/kudago/model/Location.java
@@ -1,0 +1,27 @@
+package arden.java.kudago.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.Set;
+
+@Entity
+@Table(name = "locations")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Location {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String slug;
+
+    @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private Set<Event> events;
+}

--- a/KudaGo/src/main/java/arden/java/kudago/model/Location.java
+++ b/KudaGo/src/main/java/arden/java/kudago/model/Location.java
@@ -3,6 +3,7 @@ package arden.java.kudago.model;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.HashSet;
 import java.util.Set;
 
 @Entity
@@ -23,5 +24,5 @@ public class Location {
     private String slug;
 
     @OneToMany(mappedBy = "location", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    private Set<Event> events;
+    private Set<Event> events = new HashSet<>();
 }

--- a/KudaGo/src/main/java/arden/java/kudago/model/specification/EventSpecification.java
+++ b/KudaGo/src/main/java/arden/java/kudago/model/specification/EventSpecification.java
@@ -1,0 +1,16 @@
+package arden.java.kudago.model.specification;
+
+import arden.java.kudago.model.Event;
+import net.kaczmarzyk.spring.data.jpa.domain.Between;
+import net.kaczmarzyk.spring.data.jpa.domain.Equal;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.And;
+import net.kaczmarzyk.spring.data.jpa.web.annotation.Spec;
+import org.springframework.data.jpa.domain.Specification;
+
+@And({
+        @Spec(path = "name", spec = Equal.class),
+        @Spec(path = "location.name", spec = Equal.class),
+        @Spec(path = "date", params = {"fromDate", "toDate"}, spec = Between.class, config = "yyyy-MM-dd'T'HH:mm:ssXXX")
+})
+public interface EventSpecification extends Specification<Event> {
+}

--- a/KudaGo/src/main/java/arden/java/kudago/repository/EventRepository.java
+++ b/KudaGo/src/main/java/arden/java/kudago/repository/EventRepository.java
@@ -8,11 +8,10 @@ import org.springframework.stereotype.Repository;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
-    Set<Event> findAll(Specification<Event> spec);
+    List<Event> findAll(Specification<Event> spec);
 
     static Specification<Event> buildSpecification(String name, String location, OffsetDateTime fromDate, OffsetDateTime toDate) {
         List<Specification<Event>> specs = new ArrayList<>();
@@ -24,12 +23,8 @@ public interface EventRepository extends JpaRepository<Event, Long> {
             specs.add((Specification<Event>) (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.<String>get("location").get("name"), location));
         }
 
-        if (fromDate != null) {
-            specs.add((Specification<Event>) (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.<String>get("fromDate"), fromDate));
-        }
-
-        if (toDate != null) {
-            specs.add((Specification<Event>) (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.<String>get("toDate"), toDate));
+        if (fromDate != null && toDate != null) {
+            specs.add((Specification<Event>) (root, query, criteriaBuilder) -> criteriaBuilder.between(root.get("date"), fromDate, toDate));
         }
 
         return specs.stream().reduce(Specification::and).orElse(null);

--- a/KudaGo/src/main/java/arden/java/kudago/repository/EventRepository.java
+++ b/KudaGo/src/main/java/arden/java/kudago/repository/EventRepository.java
@@ -1,0 +1,37 @@
+package arden.java.kudago.repository;
+
+import arden.java.kudago.model.Event;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@Repository
+public interface EventRepository extends JpaRepository<Event, Long> {
+    Set<Event> findAll(Specification<Event> spec);
+
+    static Specification<Event> buildSpecification(String name, String location, OffsetDateTime fromDate, OffsetDateTime toDate) {
+        List<Specification<Event>> specs = new ArrayList<>();
+        if (name != null) {
+            specs.add((Specification<Event>) (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.<String>get("name"), name));
+        }
+
+        if (location != null) {
+            specs.add((Specification<Event>) (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.<String>get("location").get("name"), location));
+        }
+
+        if (fromDate != null) {
+            specs.add((Specification<Event>) (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.<String>get("fromDate"), fromDate));
+        }
+
+        if (toDate != null) {
+            specs.add((Specification<Event>) (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.<String>get("toDate"), toDate));
+        }
+
+        return specs.stream().reduce(Specification::and).orElse(null);
+    }
+}

--- a/KudaGo/src/main/java/arden/java/kudago/repository/EventRepository.java
+++ b/KudaGo/src/main/java/arden/java/kudago/repository/EventRepository.java
@@ -1,32 +1,10 @@
 package arden.java.kudago.repository;
 
 import arden.java.kudago.model.Event;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
-import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
 @Repository
-public interface EventRepository extends JpaRepository<Event, Long> {
-    List<Event> findAll(Specification<Event> spec);
-
-    static Specification<Event> buildSpecification(String name, String location, OffsetDateTime fromDate, OffsetDateTime toDate) {
-        List<Specification<Event>> specs = new ArrayList<>();
-        if (name != null) {
-            specs.add((Specification<Event>) (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.<String>get("name"), name));
-        }
-
-        if (location != null) {
-            specs.add((Specification<Event>) (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.<String>get("location").get("name"), location));
-        }
-
-        if (fromDate != null && toDate != null) {
-            specs.add((Specification<Event>) (root, query, criteriaBuilder) -> criteriaBuilder.between(root.get("date"), fromDate, toDate));
-        }
-
-        return specs.stream().reduce(Specification::and).orElse(null);
-    }
+public interface EventRepository extends JpaRepository<Event, Long>, JpaSpecificationExecutor<Event> {
 }

--- a/KudaGo/src/main/java/arden/java/kudago/repository/LocationRepository.java
+++ b/KudaGo/src/main/java/arden/java/kudago/repository/LocationRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
-    @Query("FROM Location l JOIN FETCH l.events WHERE l.id = :id")
-    Optional<Location> findById(Long id);
+    @Query("FROM Location l LEFT JOIN FETCH l.events WHERE l.id = :id")
+    Optional<Location> findByIdEager(Long id);
 }

--- a/KudaGo/src/main/java/arden/java/kudago/repository/LocationRepository.java
+++ b/KudaGo/src/main/java/arden/java/kudago/repository/LocationRepository.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.repository;
 
-import arden.java.kudago.dto.response.places.Location;
+import arden.java.kudago.model.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;

--- a/KudaGo/src/main/java/arden/java/kudago/repository/LocationRepository.java
+++ b/KudaGo/src/main/java/arden/java/kudago/repository/LocationRepository.java
@@ -1,0 +1,14 @@
+package arden.java.kudago.repository;
+
+import arden.java.kudago.dto.response.places.Location;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface LocationRepository extends JpaRepository<Location, Long> {
+    @Query("FROM Location l JOIN FETCH l.events WHERE l.id = :id")
+    Optional<Location> findById(Long id);
+}

--- a/KudaGo/src/main/java/arden/java/kudago/repository/impl/StorageRepositoryImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/repository/impl/StorageRepositoryImpl.java
@@ -2,7 +2,6 @@ package arden.java.kudago.repository.impl;
 
 import arden.java.kudago.repository.StorageRepository;
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;

--- a/KudaGo/src/main/java/arden/java/kudago/repository/impl/StorageRepositoryImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/repository/impl/StorageRepositoryImpl.java
@@ -1,13 +1,14 @@
 package arden.java.kudago.repository.impl;
 
 import arden.java.kudago.repository.StorageRepository;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-@Repository
+@Component
 public class StorageRepositoryImpl<K, V> implements StorageRepository<K, V> {
     private final Map<K, V> storage = new ConcurrentHashMap<>();
 

--- a/KudaGo/src/main/java/arden/java/kudago/service/CategoryService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/CategoryService.java
@@ -1,17 +1,17 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.response.places.CategoryResponse;
+import arden.java.kudago.dto.response.places.CategoryDto;
 
 import java.util.List;
 
 public interface CategoryService {
-    List<CategoryResponse> getAllCategories();
+    List<CategoryDto> getAllCategories();
 
-    CategoryResponse getCategoryById(Long id);
+    CategoryDto getCategoryById(Long id);
 
-    CategoryResponse createCategory(CategoryResponse categoryResponse);
+    CategoryDto createCategory(CategoryDto categoryDto);
 
-    CategoryResponse updateCategory(Long id, CategoryResponse categoryResponse);
+    CategoryDto updateCategory(Long id, CategoryDto categoryDto);
 
     boolean deleteCategory(Long id);
 }

--- a/KudaGo/src/main/java/arden/java/kudago/service/CategoryService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/CategoryService.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.Category;
+import arden.java.kudago.dto.response.places.Category;
 
 import java.util.List;
 

--- a/KudaGo/src/main/java/arden/java/kudago/service/CategoryService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/CategoryService.java
@@ -1,17 +1,17 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.response.places.Category;
+import arden.java.kudago.dto.response.places.CategoryResponse;
 
 import java.util.List;
 
 public interface CategoryService {
-    List<Category> getAllCategories();
+    List<CategoryResponse> getAllCategories();
 
-    Category getCategoryById(Long id);
+    CategoryResponse getCategoryById(Long id);
 
-    Category createCategory(Category category);
+    CategoryResponse createCategory(CategoryResponse categoryResponse);
 
-    Category updateCategory(Long id, Category category);
+    CategoryResponse updateCategory(Long id, CategoryResponse categoryResponse);
 
     boolean deleteCategory(Long id);
 }

--- a/KudaGo/src/main/java/arden/java/kudago/service/EventService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/EventService.java
@@ -1,12 +1,18 @@
 package arden.java.kudago.service;
 
-import org.springframework.scheduling.annotation.Async;
+import arden.java.kudago.dto.response.event.EventDto;
 
-import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
 
-public interface EventService<T, U> {
-    T getEvents(LocalDate dateFrom, LocalDate dateTo);
+public interface EventService {
+    List<EventDto> getAllEvents();
+    List<EventDto> getEventsByFilter(String name, String location, OffsetDateTime fromDate, OffsetDateTime toDate);
 
-    @Async
-    U getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo);
+    EventDto getEventById(Long id);
+
+    EventDto createEvent(EventDto EventDto);
+
+    EventDto updateEvent(Long id, EventDto EventDto);
+    void deleteEvent(Long id);
 }

--- a/KudaGo/src/main/java/arden/java/kudago/service/EventService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/EventService.java
@@ -1,16 +1,14 @@
 package arden.java.kudago.service;
 
 import arden.java.kudago.dto.response.event.EventDto;
+import arden.java.kudago.model.specification.EventSpecification;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-
-import java.time.OffsetDateTime;
-import java.util.List;
 
 public interface EventService {
     Page<EventDto> getAllEvents(Pageable pageable);
 
-    List<EventDto> getEventsByFilter(String name, String location, OffsetDateTime fromDate, OffsetDateTime toDate);
+    Page<EventDto> getEventsByFilter(EventSpecification specification, Pageable pageable);
 
     EventDto getEventById(Long id);
 

--- a/KudaGo/src/main/java/arden/java/kudago/service/EventService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/EventService.java
@@ -1,16 +1,12 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.response.event.EventResponse;
-import arden.java.kudago.dto.response.event.Event;
 import org.springframework.scheduling.annotation.Async;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
-public interface EventService {
-    List<EventResponse> getEvents(LocalDate dateFrom, LocalDate dateTo);
+public interface EventService<T, U> {
+    T getEvents(LocalDate dateFrom, LocalDate dateTo);
 
     @Async
-    CompletableFuture<List<Event>> getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo);
+    U getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo);
 }

--- a/KudaGo/src/main/java/arden/java/kudago/service/EventService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/EventService.java
@@ -1,12 +1,15 @@
 package arden.java.kudago.service;
 
 import arden.java.kudago.dto.response.event.EventDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface EventService {
-    List<EventDto> getAllEvents();
+    Page<EventDto> getAllEvents(Pageable pageable);
+
     List<EventDto> getEventsByFilter(String name, String location, OffsetDateTime fromDate, OffsetDateTime toDate);
 
     EventDto getEventById(Long id);
@@ -14,5 +17,6 @@ public interface EventService {
     EventDto createEvent(EventDto EventDto);
 
     EventDto updateEvent(Long id, EventDto EventDto);
+
     void deleteEvent(Long id);
 }

--- a/KudaGo/src/main/java/arden/java/kudago/service/EventService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/EventService.java
@@ -1,0 +1,16 @@
+package arden.java.kudago.service;
+
+import arden.java.kudago.dto.response.event.EventResponse;
+import arden.java.kudago.dto.response.event.Event;
+import org.springframework.scheduling.annotation.Async;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public interface EventService {
+    List<EventResponse> getEvents(LocalDate dateFrom, LocalDate dateTo);
+
+    @Async
+    CompletableFuture<List<Event>> getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo);
+}

--- a/KudaGo/src/main/java/arden/java/kudago/service/LocationService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/LocationService.java
@@ -1,17 +1,17 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.response.places.Location;
+import arden.java.kudago.dto.response.places.LocationResponse;
 
 import java.util.List;
 
 public interface LocationService {
-    List<Location> getAllLocations();
+    List<LocationResponse> getAllLocations();
 
-    Location getLocationBySlug(String slug);
+    LocationResponse getLocationById(Long id);
 
-    Location createLocation(Location Location);
+    LocationResponse createLocation(LocationResponse LocationResponse);
 
-    Location updateLocation(String slug, Location Location);
+    LocationResponse updateLocation(Long id, LocationResponse locationResponse);
 
-    boolean deleteLocation(String slug);
+    void deleteLocation(Long id);
 }

--- a/KudaGo/src/main/java/arden/java/kudago/service/LocationService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/LocationService.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.Location;
+import arden.java.kudago.dto.response.places.Location;
 
 import java.util.List;
 

--- a/KudaGo/src/main/java/arden/java/kudago/service/LocationService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/LocationService.java
@@ -1,17 +1,17 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.response.places.LocationResponse;
+import arden.java.kudago.dto.response.places.LocationDto;
 
 import java.util.List;
 
 public interface LocationService {
-    List<LocationResponse> getAllLocations();
+    List<LocationDto> getAllLocations();
 
-    LocationResponse getLocationById(Long id);
+    LocationDto getLocationById(Long id);
 
-    LocationResponse createLocation(LocationResponse LocationResponse);
+    LocationDto createLocation(LocationDto LocationDto);
 
-    LocationResponse updateLocation(Long id, LocationResponse locationResponse);
+    LocationDto updateLocation(Long id, LocationDto locationDto);
 
     void deleteLocation(Long id);
 }

--- a/KudaGo/src/main/java/arden/java/kudago/service/SuitableEventService.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/SuitableEventService.java
@@ -1,0 +1,12 @@
+package arden.java.kudago.service;
+
+import org.springframework.scheduling.annotation.Async;
+
+import java.time.LocalDate;
+
+public interface SuitableEventService<T, U> {
+    T getEvents(LocalDate dateFrom, LocalDate dateTo);
+
+    @Async
+    U getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo);
+}

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/CategoryServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/CategoryServiceImpl.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service.impl;
 
-import arden.java.kudago.dto.Category;
+import arden.java.kudago.dto.response.places.Category;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.repository.StorageRepository;

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/CategoryServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/CategoryServiceImpl.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service.impl;
 
-import arden.java.kudago.dto.response.places.CategoryResponse;
+import arden.java.kudago.dto.response.places.CategoryDto;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.repository.StorageRepository;
@@ -15,15 +15,15 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class CategoryServiceImpl implements CategoryService {
-    private final StorageRepository<Long, CategoryResponse> categoryRepository;
+    private final StorageRepository<Long, CategoryDto> categoryRepository;
 
     @Override
-    public List<CategoryResponse> getAllCategories() {
+    public List<CategoryDto> getAllCategories() {
         return categoryRepository.readAll();
     }
 
     @Override
-    public CategoryResponse getCategoryById(Long id) {
+    public CategoryDto getCategoryById(Long id) {
         if (categoryRepository.read(id) == null) {
             throw new IdNotFoundException("Category with id = " + id + " not found");
         }
@@ -32,25 +32,25 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
-    public CategoryResponse createCategory(CategoryResponse categoryResponse) {
-        if (categoryRepository.create(categoryResponse.id(), categoryResponse) == null) {
+    public CategoryDto createCategory(CategoryDto categoryDto) {
+        if (categoryRepository.create(categoryDto.id(), categoryDto) == null) {
             throw new CreationObjectException("Could not create category, because your input format is wrong, check again");
         }
 
-        return categoryRepository.create(categoryResponse.id(), categoryResponse);
+        return categoryRepository.create(categoryDto.id(), categoryDto);
     }
 
     @Override
-    public CategoryResponse updateCategory(Long id, CategoryResponse categoryResponse) {
+    public CategoryDto updateCategory(Long id, CategoryDto categoryDto) {
         if (categoryRepository.read(id) == null) {
             throw new IdNotFoundException("Category with id = " + id + " not found");
         }
 
-        if (categoryRepository.update(id, categoryResponse) == null) {
+        if (categoryRepository.update(id, categoryDto) == null) {
             throw new CreationObjectException("Could not update category, because your input format is wrong, check again");
         }
 
-        return categoryRepository.update(id, categoryResponse);
+        return categoryRepository.update(id, categoryDto);
     }
 
     @Override

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/CategoryServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/CategoryServiceImpl.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service.impl;
 
-import arden.java.kudago.dto.response.places.Category;
+import arden.java.kudago.dto.response.places.CategoryResponse;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.repository.StorageRepository;
@@ -15,15 +15,15 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class CategoryServiceImpl implements CategoryService {
-    private final StorageRepository<Long, Category> categoryRepository;
+    private final StorageRepository<Long, CategoryResponse> categoryRepository;
 
     @Override
-    public List<Category> getAllCategories() {
+    public List<CategoryResponse> getAllCategories() {
         return categoryRepository.readAll();
     }
 
     @Override
-    public Category getCategoryById(Long id) {
+    public CategoryResponse getCategoryById(Long id) {
         if (categoryRepository.read(id) == null) {
             throw new IdNotFoundException("Category with id = " + id + " not found");
         }
@@ -32,25 +32,25 @@ public class CategoryServiceImpl implements CategoryService {
     }
 
     @Override
-    public Category createCategory(Category category) {
-        if (categoryRepository.create(category.id(), category) == null) {
+    public CategoryResponse createCategory(CategoryResponse categoryResponse) {
+        if (categoryRepository.create(categoryResponse.id(), categoryResponse) == null) {
             throw new CreationObjectException("Could not create category, because your input format is wrong, check again");
         }
 
-        return categoryRepository.create(category.id(), category);
+        return categoryRepository.create(categoryResponse.id(), categoryResponse);
     }
 
     @Override
-    public Category updateCategory(Long id, Category category) {
+    public CategoryResponse updateCategory(Long id, CategoryResponse categoryResponse) {
         if (categoryRepository.read(id) == null) {
             throw new IdNotFoundException("Category with id = " + id + " not found");
         }
 
-        if (categoryRepository.update(id, category) == null) {
+        if (categoryRepository.update(id, categoryResponse) == null) {
             throw new CreationObjectException("Could not update category, because your input format is wrong, check again");
         }
 
-        return categoryRepository.update(id, category);
+        return categoryRepository.update(id, categoryResponse);
     }
 
     @Override

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
@@ -4,13 +4,13 @@ import arden.java.kudago.dto.response.event.EventDto;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.model.Event;
 import arden.java.kudago.repository.EventRepository;
+import arden.java.kudago.repository.LocationRepository;
 import arden.java.kudago.service.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -44,10 +44,14 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public EventDto updateEvent(Long id, EventDto eventDto) {
-        Optional<Event> event = eventRepository.findById(id);
-        if (event.isPresent()) {
-            return createResponseFromEvent(eventRepository.save(createEventFromResponse(eventDto)));
-        } else throw new IdNotFoundException("Event with id '" + id + "' not found");
+        Event existingEvent = eventRepository.findById(id)
+                .orElseThrow(() -> new IdNotFoundException("Event with id '" + id + "' not found"));
+
+        existingEvent.setName(eventDto.name());
+        existingEvent.setDate(eventDto.date());
+        existingEvent.setLocation(eventDto.location());
+
+        return createResponseFromEvent(eventRepository.save(existingEvent));
     }
 
     @Override

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
@@ -4,7 +4,6 @@ import arden.java.kudago.dto.response.event.EventDto;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.model.Event;
 import arden.java.kudago.repository.EventRepository;
-import arden.java.kudago.repository.LocationRepository;
 import arden.java.kudago.service.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
@@ -1,0 +1,109 @@
+package arden.java.kudago.service.impl;
+
+import arden.java.kudago.client.CurrencyRestTemplate;
+import arden.java.kudago.client.EventRestTemplate;
+import arden.java.kudago.dto.request.CurrencyConvertRequest;
+import arden.java.kudago.dto.response.event.Event;
+import arden.java.kudago.dto.response.event.EventResponse;
+import arden.java.kudago.exception.GeneralException;
+import arden.java.kudago.service.EventService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class EventServiceImpl implements EventService {
+    private final EventRestTemplate eventRestTemplate;
+    private final CurrencyRestTemplate currencyRestTemplate;
+
+    @Qualifier("fixedThreadPool")
+    private final ExecutorService fixedThreadPool;
+
+    @Override
+    public CompletableFuture<List<Event>> getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo) {
+        CompletableFuture<List<EventResponse>> eventsRequest = CompletableFuture.supplyAsync(() -> getEvents(dateFrom, dateTo), fixedThreadPool);
+        CompletableFuture<Double> convertedPrice = CompletableFuture.supplyAsync(() -> currencyRestTemplate.convertPrice(CurrencyConvertRequest.builder()
+                .fromCurrency(currency)
+                .toCurrency("RUB")
+                .amount(budget)
+                .build()).orElseThrow(() -> new GeneralException("Сервер не доступен")), fixedThreadPool);
+
+        return eventsRequest.thenCombine(convertedPrice, (events, price) ->
+                events.stream()
+                        .filter(event -> parseEventPrice(event.price()) <= price)
+                        .sorted(Comparator.comparing(EventResponse::favoritesCount).reversed())
+                        .map(event -> Event.builder()
+                                .id(event.id())
+                                .title(event.title())
+                                .siteUrl(event.siteUrl())
+                                .description(event.description().replace("<p>", "").replace("</p>", ""))
+                                .favoritesCount(event.favoritesCount())
+                                .price(!parseEventPrice(event.price()).equals(0D) ? parseEventPrice(event.price()).toString() : "бесплатно")
+                                .dates(event.dates().stream()
+                                        .map(date -> Event.ConvertedDates.builder()
+                                                .start(toLocalDate(date.start()))
+                                                .end(toLocalDate(date.end())).build())
+                                        .filter(convertedDates -> {
+                                            LocalDate from;
+                                            LocalDate to;
+                                            from = Objects.requireNonNullElseGet(dateFrom, LocalDate::now);
+                                            to = Objects.requireNonNullElseGet(dateTo, () -> LocalDate.now().plusWeeks(1));
+
+                                            return convertedDates.start().isAfter(from) && convertedDates.end().isBefore(to);
+                                        })
+                                        .toList())
+                                .build())
+                        .toList());
+    }
+
+    @Override
+    public List<EventResponse> getEvents(LocalDate dateFrom, LocalDate dateTo) {
+        long start, end;
+        if (dateFrom == null || dateTo == null) {
+            start = toEpochSeconds(LocalDate.now());
+            end = toEpochSeconds(LocalDate.now().plusWeeks(1));
+        } else {
+            start = toEpochSeconds(dateFrom);
+            end = toEpochSeconds(dateTo);
+        }
+
+        Optional<List<EventResponse>> events = eventRestTemplate.getEvents(start, end);
+
+        if (events.isPresent()) {
+            return events.get();
+        }
+
+        throw new GeneralException("No events found");
+    }
+
+    public Double parseEventPrice(String event) {
+        Pattern pattern = Pattern.compile("\\d+");
+        Matcher matcher = pattern.matcher(event);
+
+        return matcher.find() ? Double.parseDouble(matcher.group()) : 0D;
+    }
+
+    public LocalDate toLocalDate(Long date) {
+        return Instant.ofEpochSecond(date).atZone(ZoneOffset.UTC).toLocalDate();
+    }
+
+    public long toEpochSeconds(LocalDate date) {
+        return date.atStartOfDay(ZoneId.systemDefault()).toEpochSecond();
+    }
+}

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
@@ -1,22 +1,25 @@
 package arden.java.kudago.service.impl;
 
 import arden.java.kudago.dto.response.event.EventDto;
+import arden.java.kudago.exception.GeneralException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.model.Event;
+import arden.java.kudago.model.specification.EventSpecification;
 import arden.java.kudago.repository.EventRepository;
+import arden.java.kudago.repository.LocationRepository;
 import arden.java.kudago.service.EventService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.data.domain.Page;
-
-import java.time.OffsetDateTime;
-import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class EventServiceImpl implements EventService {
     private final EventRepository eventRepository;
+    private final LocationServiceImpl locationService;
+    private final LocationRepository locationRepository;
 
     @Override
     public Page<EventDto> getAllEvents(Pageable pageable) {
@@ -25,10 +28,9 @@ public class EventServiceImpl implements EventService {
     }
 
     @Override
-    public List<EventDto> getEventsByFilter(String name, String location, OffsetDateTime fromDate, OffsetDateTime toDate) {
-        return eventRepository.findAll(EventRepository.buildSpecification(name, location, fromDate, toDate)).stream()
-                .map(this::createResponseFromEvent)
-                .toList();
+    public Page<EventDto> getEventsByFilter(EventSpecification specification, Pageable pageable) {
+        return eventRepository.findAll(specification, pageable)
+                .map(this::createResponseFromEvent);
     }
 
     @Override
@@ -39,17 +41,23 @@ public class EventServiceImpl implements EventService {
 
     @Override
     public EventDto createEvent(EventDto eventDto) {
+        Long locationId = eventDto.locationId();
+        if (locationRepository.findByIdEager(locationId).isEmpty()) {
+            throw new GeneralException("Location does not exist");
+        }
+
         return createResponseFromEvent(eventRepository.save(createEventFromResponse(eventDto)));
     }
 
     @Override
+    @Transactional
     public EventDto updateEvent(Long id, EventDto eventDto) {
         Event existingEvent = eventRepository.findById(id)
                 .orElseThrow(() -> new IdNotFoundException("Event with id '" + id + "' not found"));
 
         existingEvent.setName(eventDto.name());
         existingEvent.setDate(eventDto.date());
-        existingEvent.setLocation(eventDto.location());
+        existingEvent.setLocation(locationRepository.findByIdEager(eventDto.locationId()).orElseThrow(() -> new IdNotFoundException("Location with id '" + eventDto.locationId() + "' not found")));
 
         return createResponseFromEvent(eventRepository.save(existingEvent));
     }
@@ -63,7 +71,7 @@ public class EventServiceImpl implements EventService {
         return EventDto.builder()
                 .name(event.getName())
                 .date(event.getDate())
-                .location(event.getLocation())
+                .locationId(event.getLocation().getId())
                 .build();
     }
 
@@ -71,7 +79,7 @@ public class EventServiceImpl implements EventService {
         Event event = new Event();
         event.setName(eventDto.name());
         event.setDate(eventDto.date());
-        event.setLocation(eventDto.location());
+        event.setLocation(locationRepository.findByIdEager(eventDto.locationId()).orElseThrow(() -> new IdNotFoundException("Location with id '" + eventDto.locationId() + "' not found")));
 
         return event;
     }

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
@@ -10,6 +10,7 @@ import arden.java.kudago.service.EventService;
 import arden.java.kudago.utils.DateParser;
 import arden.java.kudago.utils.PriceParser;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
@@ -20,65 +21,88 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Semaphore;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class EventServiceImpl implements EventService<List<EventResponse>, CompletableFuture<List<Event>>> {
     private final EventRestTemplate eventRestTemplate;
     private final CurrencyRestTemplate currencyRestTemplate;
+    private final Semaphore semaphore;
 
     @Qualifier("fixedThreadPool")
     private final ExecutorService fixedThreadPool;
 
     @Override
     public List<EventResponse> getEvents(LocalDate dateFrom, LocalDate dateTo) {
-        long start = DateParser.toEpochSeconds(Objects.requireNonNullElseGet(dateFrom, LocalDate::now));
-        long end = DateParser.toEpochSeconds(Objects.requireNonNullElseGet(dateTo, () -> LocalDate.now().plusWeeks(1)));
+        try {
+            semaphore.acquire();
+            log.info("Starting to get all events");
+            long start = DateParser.toEpochSeconds(Objects.requireNonNullElseGet(dateFrom, LocalDate::now));
+            long end = DateParser.toEpochSeconds(Objects.requireNonNullElseGet(dateTo, () -> LocalDate.now().plusWeeks(1)));
 
-        Optional<List<EventResponse>> events = eventRestTemplate.getEvents(start, end);
+            Optional<List<EventResponse>> events = eventRestTemplate.getEvents(start, end);
 
-        if (events.isPresent()) {
-            return events.get();
+            if (events.isPresent()) {
+                log.info("Found {} events", events.get().size());
+                return events.get();
+            }
+
+            log.error("No events found");
+            throw new GeneralException("No events found");
+        } catch (InterruptedException e) {
+            log.error("Interrupted exception", e);
+            throw new GeneralException("Interrupted exception");
+        } finally {
+            semaphore.release();
         }
-
-        throw new GeneralException("No events found");
     }
 
     @Override
     public CompletableFuture<List<Event>> getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo) {
-        CompletableFuture<List<EventResponse>> eventsRequest = CompletableFuture.supplyAsync(() -> getEvents(dateFrom, dateTo), fixedThreadPool);
-        CompletableFuture<Double> convertedPrice = CompletableFuture.supplyAsync(() -> currencyRestTemplate.convertPrice(CurrencyConvertRequest.builder()
-                .fromCurrency(currency)
-                .toCurrency("RUB")
-                .amount(budget)
-                .build()).orElseThrow(() -> new GeneralException("Сервер не доступен")), fixedThreadPool);
+        try {
+            semaphore.acquire();
+            log.info("Starting to get suitable events");
+            CompletableFuture<List<EventResponse>> eventsRequest = CompletableFuture.supplyAsync(() -> getEvents(dateFrom, dateTo), fixedThreadPool);
+            CompletableFuture<Double> convertedPrice = CompletableFuture.supplyAsync(() -> currencyRestTemplate.convertPrice(CurrencyConvertRequest.builder()
+                    .fromCurrency(currency)
+                    .toCurrency("RUB")
+                    .amount(budget)
+                    .build()).orElseThrow(() -> new GeneralException("Сервер не доступен")), fixedThreadPool);
 
-        return eventsRequest.thenCombine(convertedPrice, (events, price) ->
-                events.stream()
-                        .filter(event -> PriceParser.parseEventPrice(event.price()) <= price)
-                        .sorted(Comparator.comparing(EventResponse::favoritesCount).reversed())
-                        .map(event -> Event.builder()
-                                .id(event.id())
-                                .title(event.title())
-                                .siteUrl(event.siteUrl())
-                                .description(event.description().replace("<p>", "").replace("</p>", ""))
-                                .favoritesCount(event.favoritesCount())
-                                .price(!PriceParser.parseEventPrice(event.price()).equals(0D) ? PriceParser.parseEventPrice(event.price()).toString() : "бесплатно")
-                                .dates(event.dates().stream()
-                                        .map(date -> Event.ConvertedDates.builder()
-                                                .start(DateParser.toLocalDate(date.start()))
-                                                .end(DateParser.toLocalDate(date.end())).build())
-                                        .filter(convertedDates -> {
-                                            LocalDate from;
-                                            LocalDate to;
-                                            from = Objects.requireNonNullElseGet(dateFrom, LocalDate::now);
-                                            to = Objects.requireNonNullElseGet(dateTo, () -> LocalDate.now().plusWeeks(1));
+            log.info("Finished to get suitable events");
+            return eventsRequest.thenCombine(convertedPrice, (events, price) ->
+                    events.stream()
+                            .filter(event -> PriceParser.parseEventPrice(event.price()) <= price)
+                            .sorted(Comparator.comparing(EventResponse::favoritesCount).reversed())
+                            .map(event -> Event.builder()
+                                    .id(event.id())
+                                    .title(event.title())
+                                    .siteUrl(event.siteUrl())
+                                    .description(event.description().replace("<p>", "").replace("</p>", ""))
+                                    .favoritesCount(event.favoritesCount())
+                                    .price(!PriceParser.parseEventPrice(event.price()).equals(0D) ? PriceParser.parseEventPrice(event.price()).toString() : "бесплатно")
+                                    .dates(event.dates().stream()
+                                            .map(date -> Event.ConvertedDates.builder()
+                                                    .start(DateParser.toLocalDate(date.start()))
+                                                    .end(DateParser.toLocalDate(date.end())).build())
+                                            .filter(convertedDates -> {
+                                                LocalDate from;
+                                                LocalDate to;
+                                                from = Objects.requireNonNullElseGet(dateFrom, LocalDate::now);
+                                                to = Objects.requireNonNullElseGet(dateTo, () -> LocalDate.now().plusWeeks(1));
 
-                                            return convertedDates.start().isAfter(from) && convertedDates.end().isBefore(to);
-                                        })
-                                        .toList())
-                                .build())
-                        .toList());
+                                                return convertedDates.start().isAfter(from) && convertedDates.end().isBefore(to);
+                                            })
+                                            .toList())
+                                    .build())
+                            .toList());
+        } catch (InterruptedException e) {
+            log.error("Interrupted exception", e);
+            throw new GeneralException("Interrupted exception");
+        } finally {
+            semaphore.release();
+        }
     }
-
 }

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
@@ -1,108 +1,74 @@
 package arden.java.kudago.service.impl;
 
-import arden.java.kudago.client.CurrencyRestTemplate;
-import arden.java.kudago.client.EventRestTemplate;
-import arden.java.kudago.dto.request.CurrencyConvertRequest;
-import arden.java.kudago.dto.response.event.Event;
-import arden.java.kudago.dto.response.event.EventResponse;
-import arden.java.kudago.exception.GeneralException;
+import arden.java.kudago.dto.response.event.EventDto;
+import arden.java.kudago.exception.IdNotFoundException;
+import arden.java.kudago.model.Event;
+import arden.java.kudago.repository.EventRepository;
 import arden.java.kudago.service.EventService;
-import arden.java.kudago.utils.DateParser;
-import arden.java.kudago.utils.PriceParser;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDate;
-import java.util.Comparator;
+import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Semaphore;
 
 @Service
-@Slf4j
 @RequiredArgsConstructor
-public class EventServiceImpl implements EventService<List<EventResponse>, CompletableFuture<List<Event>>> {
-    private final EventRestTemplate eventRestTemplate;
-    private final CurrencyRestTemplate currencyRestTemplate;
-    private final Semaphore semaphore;
-
-    @Qualifier("fixedThreadPool")
-    private final ExecutorService fixedThreadPool;
+public class EventServiceImpl implements EventService {
+    private final EventRepository eventRepository;
 
     @Override
-    public List<EventResponse> getEvents(LocalDate dateFrom, LocalDate dateTo) {
-        try {
-            semaphore.acquire();
-            log.info("Starting to get all events");
-            long start = DateParser.toEpochSeconds(Objects.requireNonNullElseGet(dateFrom, LocalDate::now));
-            long end = DateParser.toEpochSeconds(Objects.requireNonNullElseGet(dateTo, () -> LocalDate.now().plusWeeks(1)));
-
-            Optional<List<EventResponse>> events = eventRestTemplate.getEvents(start, end);
-
-            if (events.isPresent()) {
-                log.info("Found {} events", events.get().size());
-                return events.get();
-            }
-
-            log.error("No events found");
-            throw new GeneralException("No events found");
-        } catch (InterruptedException e) {
-            log.error("Interrupted exception", e);
-            throw new GeneralException("Interrupted exception");
-        } finally {
-            semaphore.release();
-        }
+    public List<EventDto> getAllEvents() {
+        return eventRepository.findAll().stream()
+                .map(this::createResponseFromEvent)
+                .toList();
     }
 
     @Override
-    public CompletableFuture<List<Event>> getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo) {
-        try {
-            semaphore.acquire();
-            log.info("Starting to get suitable events");
-            CompletableFuture<List<EventResponse>> eventsRequest = CompletableFuture.supplyAsync(() -> getEvents(dateFrom, dateTo), fixedThreadPool);
-            CompletableFuture<Double> convertedPrice = CompletableFuture.supplyAsync(() -> currencyRestTemplate.convertPrice(CurrencyConvertRequest.builder()
-                    .fromCurrency(currency)
-                    .toCurrency("RUB")
-                    .amount(budget)
-                    .build()).orElseThrow(() -> new GeneralException("Сервер не доступен")), fixedThreadPool);
+    public List<EventDto> getEventsByFilter(String name, String location, OffsetDateTime fromDate, OffsetDateTime toDate) {
+        return eventRepository.findAll(EventRepository.buildSpecification(name, location, fromDate, toDate)).stream()
+                .map(this::createResponseFromEvent)
+                .toList();
+    }
 
-            log.info("Finished to get suitable events");
-            return eventsRequest.thenCombine(convertedPrice, (events, price) ->
-                    events.stream()
-                            .filter(event -> PriceParser.parseEventPrice(event.price()) <= price)
-                            .sorted(Comparator.comparing(EventResponse::favoritesCount).reversed())
-                            .map(event -> Event.builder()
-                                    .id(event.id())
-                                    .title(event.title())
-                                    .siteUrl(event.siteUrl())
-                                    .description(event.description().replace("<p>", "").replace("</p>", ""))
-                                    .favoritesCount(event.favoritesCount())
-                                    .price(!PriceParser.parseEventPrice(event.price()).equals(0D) ? PriceParser.parseEventPrice(event.price()).toString() : "бесплатно")
-                                    .dates(event.dates().stream()
-                                            .map(date -> Event.ConvertedDates.builder()
-                                                    .start(DateParser.toLocalDate(date.start()))
-                                                    .end(DateParser.toLocalDate(date.end())).build())
-                                            .filter(convertedDates -> {
-                                                LocalDate from;
-                                                LocalDate to;
-                                                from = Objects.requireNonNullElseGet(dateFrom, LocalDate::now);
-                                                to = Objects.requireNonNullElseGet(dateTo, () -> LocalDate.now().plusWeeks(1));
+    @Override
+    public EventDto getEventById(Long id) {
+        return createResponseFromEvent(eventRepository.findById(id)
+                .orElseThrow(() -> new IdNotFoundException("Event with id '" + id + "' not found")));
+    }
 
-                                                return convertedDates.start().isAfter(from) && convertedDates.end().isBefore(to);
-                                            })
-                                            .toList())
-                                    .build())
-                            .toList());
-        } catch (InterruptedException e) {
-            log.error("Interrupted exception", e);
-            throw new GeneralException("Interrupted exception");
-        } finally {
-            semaphore.release();
-        }
+    @Override
+    public EventDto createEvent(EventDto eventDto) {
+        return createResponseFromEvent(eventRepository.save(createEventFromResponse(eventDto)));
+    }
+
+    @Override
+    public EventDto updateEvent(Long id, EventDto eventDto) {
+        Optional<Event> event = eventRepository.findById(id);
+        if (event.isPresent()) {
+            return createResponseFromEvent(eventRepository.save(createEventFromResponse(eventDto)));
+        } else throw new IdNotFoundException("Event with id '" + id + "' not found");
+    }
+
+    @Override
+    public void deleteEvent(Long id) {
+        eventRepository.deleteById(id);
+    }
+
+    private EventDto createResponseFromEvent(Event event) {
+        return EventDto.builder()
+                .name(event.getName())
+                .date(event.getDate())
+                .location(event.getLocation())
+                .build();
+    }
+
+    private Event createEventFromResponse(EventDto eventDto) {
+        Event event = new Event();
+        event.setName(eventDto.name());
+        event.setDate(eventDto.date());
+        event.setLocation(eventDto.location());
+
+        return event;
     }
 }

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceImpl.java
@@ -6,7 +6,9 @@ import arden.java.kudago.model.Event;
 import arden.java.kudago.repository.EventRepository;
 import arden.java.kudago.service.EventService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.data.domain.Page;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -17,10 +19,9 @@ public class EventServiceImpl implements EventService {
     private final EventRepository eventRepository;
 
     @Override
-    public List<EventDto> getAllEvents() {
-        return eventRepository.findAll().stream()
-                .map(this::createResponseFromEvent)
-                .toList();
+    public Page<EventDto> getAllEvents(Pageable pageable) {
+        return eventRepository.findAll(pageable)
+                .map(this::createResponseFromEvent);
     }
 
     @Override

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceReactiveImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/EventServiceReactiveImpl.java
@@ -1,0 +1,82 @@
+package arden.java.kudago.service.impl;
+
+import arden.java.kudago.client.CurrencyRestTemplate;
+import arden.java.kudago.client.EventRestTemplate;
+import arden.java.kudago.dto.request.CurrencyConvertRequest;
+import arden.java.kudago.dto.response.event.Event;
+import arden.java.kudago.dto.response.event.EventResponse;
+import arden.java.kudago.exception.GeneralException;
+import arden.java.kudago.service.EventService;
+import arden.java.kudago.utils.DateParser;
+import arden.java.kudago.utils.PriceParser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EventServiceReactiveImpl implements EventService<Mono<List<EventResponse>>, Mono<List<Event>>> {
+    private final EventRestTemplate eventRestTemplate;
+    private final CurrencyRestTemplate currencyRestTemplate;
+
+    @Override
+    public Mono<List<EventResponse>> getEvents(LocalDate dateFrom, LocalDate dateTo) {
+        long start = DateParser.toEpochSeconds(Objects.requireNonNullElseGet(dateFrom, LocalDate::now));
+        long end = DateParser.toEpochSeconds(Objects.requireNonNullElseGet(dateTo, () -> LocalDate.now().plusWeeks(1)));
+
+        Optional<List<EventResponse>> events = eventRestTemplate.getEvents(start, end);
+
+        if (events.isPresent()) {
+            return Mono.just(events.get());
+        }
+
+        throw new GeneralException("No events found");
+    }
+
+    @Override
+    public Mono<List<Event>> getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo) {
+        Mono<List<EventResponse>> eventsMono = getEvents(dateFrom, dateTo);
+        Mono<Double> convertedPriceMono = Mono.just(currencyRestTemplate.convertPrice(CurrencyConvertRequest.builder()
+                        .fromCurrency(currency)
+                        .toCurrency("RUB")
+                        .amount(budget)
+                        .build())
+                .orElseThrow(() -> new GeneralException("Сервер не доступен")));
+
+        return Mono.zip(eventsMono, convertedPriceMono)
+                .flatMap(tuple -> {
+                    List<EventResponse> events = tuple.getT1();
+                    Double price = tuple.getT2();
+
+                    return Flux.fromIterable(events)
+                            .filter(event -> PriceParser.parseEventPrice(event.price()) <= price)
+                            .sort(Comparator.comparing(EventResponse::favoritesCount).reversed())
+                            .map(event -> Event.builder()
+                                    .id(event.id())
+                                    .title(event.title())
+                                    .siteUrl(event.siteUrl())
+                                    .description(event.description().replace("<p>", "").replace("</p>", ""))
+                                    .favoritesCount(event.favoritesCount())
+                                    .price(!PriceParser.parseEventPrice(event.price()).equals(0D) ? PriceParser.parseEventPrice(event.price()).toString() : "бесплатно")
+                                    .dates(event.dates().stream()
+                                            .map(date -> Event.ConvertedDates.builder()
+                                                    .start(DateParser.toLocalDate(date.start()))
+                                                    .end(DateParser.toLocalDate(date.end())).build())
+                                            .filter(convertedDates -> {
+                                                LocalDate from = Objects.requireNonNullElseGet(dateFrom, LocalDate::now);
+                                                LocalDate to = Objects.requireNonNullElseGet(dateTo, () -> LocalDate.now().plusWeeks(1));
+                                                return convertedDates.start().isAfter(from) && convertedDates.end().isBefore(to);
+                                            })
+                                            .toList())
+                                    .build())
+                            .collectList();
+                });
+    }
+}

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/LocationServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/LocationServiceImpl.java
@@ -51,11 +51,11 @@ public class LocationServiceImpl implements LocationService {
         locationRepository.deleteById(id);
     }
 
-    private LocationDto createResponseFromLocation(Location location) {
+    public LocationDto createResponseFromLocation(Location location) {
         return new LocationDto(location.getSlug(), location.getName());
     }
 
-    private Location createLocationFromResponse(LocationDto locationDto) {
+    public Location createLocationFromResponse(LocationDto locationDto) {
         Location location = new Location();
         location.setName(locationDto.name());
         location.setSlug(locationDto.slug());

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/LocationServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/LocationServiceImpl.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service.impl;
 
-import arden.java.kudago.dto.Location;
+import arden.java.kudago.dto.response.places.Location;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.repository.StorageRepository;

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/LocationServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/LocationServiceImpl.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service.impl;
 
-import arden.java.kudago.dto.response.places.LocationResponse;
+import arden.java.kudago.dto.response.places.LocationDto;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.model.Location;
 import arden.java.kudago.repository.LocationRepository;
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,29 +18,32 @@ public class LocationServiceImpl implements LocationService {
     private final LocationRepository locationRepository;
 
     @Override
-    public List<LocationResponse> getAllLocations() {
+    public List<LocationDto> getAllLocations() {
         return locationRepository.findAll().stream()
                 .map(this::createResponseFromLocation)
                 .toList();
     }
 
     @Override
-    public LocationResponse getLocationById(Long id) {
-        return createResponseFromLocation(locationRepository.findById(id)
+    public LocationDto getLocationById(Long id) {
+        return createResponseFromLocation(locationRepository.findByIdEager(id)
                 .orElseThrow(() -> new IdNotFoundException("Location with id '" + id + "' not found")));
     }
 
     @Override
-    public LocationResponse createLocation(LocationResponse locationResponse) {
-        return createResponseFromLocation(locationRepository.save(createLocationFromResponse(locationResponse)));
+    public LocationDto createLocation(LocationDto locationDto) {
+        return createResponseFromLocation(locationRepository.save(createLocationFromResponse(locationDto)));
     }
 
     @Override
-    public LocationResponse updateLocation(Long id, LocationResponse locationResponse) {
-        Optional<Location> location = locationRepository.findById(id);
-        if (location.isPresent()) {
-            return createResponseFromLocation(locationRepository.save(createLocationFromResponse(locationResponse)));
-        } else throw new IdNotFoundException("Location with id '" + id + "' not found");
+    public LocationDto updateLocation(Long id, LocationDto locationDto) {
+        Location existingLocation = locationRepository.findByIdEager(id)
+                .orElseThrow(() -> new IdNotFoundException("Location with id '" + id + "' not found"));
+
+        existingLocation.setName(locationDto.name());
+        existingLocation.setSlug(locationDto.slug());
+
+        return createResponseFromLocation(locationRepository.save(existingLocation));
     }
 
     @Override
@@ -49,14 +51,14 @@ public class LocationServiceImpl implements LocationService {
         locationRepository.deleteById(id);
     }
 
-    private LocationResponse createResponseFromLocation(Location location) {
-        return new LocationResponse(location.getSlug(), location.getName());
+    private LocationDto createResponseFromLocation(Location location) {
+        return new LocationDto(location.getSlug(), location.getName());
     }
 
-    private Location createLocationFromResponse(LocationResponse locationResponse) {
+    private Location createLocationFromResponse(LocationDto locationDto) {
         Location location = new Location();
-        location.setName(locationResponse.name());
-        location.setSlug(locationResponse.slug());
+        location.setName(locationDto.name());
+        location.setSlug(locationDto.slug());
 
         return location;
     }

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/LocationServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/LocationServiceImpl.java
@@ -1,64 +1,63 @@
 package arden.java.kudago.service.impl;
 
-import arden.java.kudago.dto.response.places.Location;
-import arden.java.kudago.exception.CreationObjectException;
+import arden.java.kudago.dto.response.places.LocationResponse;
 import arden.java.kudago.exception.IdNotFoundException;
-import arden.java.kudago.repository.StorageRepository;
+import arden.java.kudago.model.Location;
+import arden.java.kudago.repository.LocationRepository;
 import arden.java.kudago.service.LocationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class LocationServiceImpl implements LocationService {
-    private final StorageRepository<String, Location> locationStorage;
+    private final LocationRepository locationRepository;
 
     @Override
-    public List<Location> getAllLocations() {
-        return locationStorage.readAll();
+    public List<LocationResponse> getAllLocations() {
+        return locationRepository.findAll().stream()
+                .map(this::createResponseFromLocation)
+                .toList();
     }
 
     @Override
-    public Location getLocationBySlug(String slug) {
-        if (locationStorage.read(slug) == null) {
-            throw new IdNotFoundException("Location with slug '" + slug + "' not found");
-        }
-
-        return locationStorage.read(slug);
+    public LocationResponse getLocationById(Long id) {
+        return createResponseFromLocation(locationRepository.findById(id)
+                .orElseThrow(() -> new IdNotFoundException("Location with id '" + id + "' not found")));
     }
 
     @Override
-    public Location createLocation(Location location) {
-        if (locationStorage.create(location.slug(), location) == null) {
-            throw new CreationObjectException("Could not create location, because your input format is wrong, check again");
-        }
-
-        return locationStorage.create(location.slug(), location);
+    public LocationResponse createLocation(LocationResponse locationResponse) {
+        return createResponseFromLocation(locationRepository.save(createLocationFromResponse(locationResponse)));
     }
 
     @Override
-    public Location updateLocation(String slug, Location location) {
-        if (locationStorage.read(slug) == null) {
-            throw new IdNotFoundException("Location with slug '" + slug + "' not found");
-        }
-
-        if (locationStorage.update(slug, location) == null) {
-            throw new CreationObjectException("Could not update location, because your input format is wrong, check again");
-        }
-
-        return locationStorage.update(slug, location);
+    public LocationResponse updateLocation(Long id, LocationResponse locationResponse) {
+        Optional<Location> location = locationRepository.findById(id);
+        if (location.isPresent()) {
+            return createResponseFromLocation(locationRepository.save(createLocationFromResponse(locationResponse)));
+        } else throw new IdNotFoundException("Location with id '" + id + "' not found");
     }
 
     @Override
-    public boolean deleteLocation(String slug) {
-        if (locationStorage.read(slug) == null || !locationStorage.delete(slug)) {
-            throw new IdNotFoundException("Location with slug '" + slug + "' not found");
-        }
+    public void deleteLocation(Long id) {
+        locationRepository.deleteById(id);
+    }
 
-        return locationStorage.delete(slug);
+    private LocationResponse createResponseFromLocation(Location location) {
+        return new LocationResponse(location.getSlug(), location.getName());
+    }
+
+    private Location createLocationFromResponse(LocationResponse locationResponse) {
+        Location location = new Location();
+        location.setName(locationResponse.name());
+        location.setSlug(locationResponse.slug());
+
+        return location;
     }
 }

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/SuitableEventServiceImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/SuitableEventServiceImpl.java
@@ -1,0 +1,108 @@
+package arden.java.kudago.service.impl;
+
+import arden.java.kudago.client.CurrencyRestTemplate;
+import arden.java.kudago.client.EventRestTemplate;
+import arden.java.kudago.dto.request.CurrencyConvertRequest;
+import arden.java.kudago.dto.response.event.SuitableEvent;
+import arden.java.kudago.dto.response.event.EventResponse;
+import arden.java.kudago.exception.GeneralException;
+import arden.java.kudago.service.SuitableEventService;
+import arden.java.kudago.utils.DateParser;
+import arden.java.kudago.utils.PriceParser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Semaphore;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SuitableEventServiceImpl implements SuitableEventService<List<EventResponse>, CompletableFuture<List<SuitableEvent>>> {
+    private final EventRestTemplate eventRestTemplate;
+    private final CurrencyRestTemplate currencyRestTemplate;
+    private final Semaphore semaphore;
+
+    @Qualifier("fixedThreadPool")
+    private final ExecutorService fixedThreadPool;
+
+    @Override
+    public List<EventResponse> getEvents(LocalDate dateFrom, LocalDate dateTo) {
+        try {
+            semaphore.acquire();
+            log.info("Starting to get all events");
+            long start = DateParser.toEpochSeconds(Objects.requireNonNullElseGet(dateFrom, LocalDate::now));
+            long end = DateParser.toEpochSeconds(Objects.requireNonNullElseGet(dateTo, () -> LocalDate.now().plusWeeks(1)));
+
+            Optional<List<EventResponse>> events = eventRestTemplate.getEvents(start, end);
+
+            if (events.isPresent()) {
+                log.info("Found {} events", events.get().size());
+                return events.get();
+            }
+
+            log.error("No events found");
+            throw new GeneralException("No events found");
+        } catch (InterruptedException e) {
+            log.error("Interrupted exception", e);
+            throw new GeneralException("Interrupted exception");
+        } finally {
+            semaphore.release();
+        }
+    }
+
+    @Override
+    public CompletableFuture<List<SuitableEvent>> getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo) {
+        try {
+            semaphore.acquire();
+            log.info("Starting to get suitable events");
+            CompletableFuture<List<EventResponse>> eventsRequest = CompletableFuture.supplyAsync(() -> getEvents(dateFrom, dateTo), fixedThreadPool);
+            CompletableFuture<Double> convertedPrice = CompletableFuture.supplyAsync(() -> currencyRestTemplate.convertPrice(CurrencyConvertRequest.builder()
+                    .fromCurrency(currency)
+                    .toCurrency("RUB")
+                    .amount(budget)
+                    .build()).orElseThrow(() -> new GeneralException("Сервер не доступен")), fixedThreadPool);
+
+            log.info("Finished to get suitable events");
+            return eventsRequest.thenCombine(convertedPrice, (events, price) ->
+                    events.stream()
+                            .filter(event -> PriceParser.parseEventPrice(event.price()) <= price)
+                            .sorted(Comparator.comparing(EventResponse::favoritesCount).reversed())
+                            .map(event -> SuitableEvent.builder()
+                                    .id(event.id())
+                                    .title(event.title())
+                                    .siteUrl(event.siteUrl())
+                                    .description(event.description().replace("<p>", "").replace("</p>", ""))
+                                    .favoritesCount(event.favoritesCount())
+                                    .price(!PriceParser.parseEventPrice(event.price()).equals(0D) ? PriceParser.parseEventPrice(event.price()).toString() : "бесплатно")
+                                    .dates(event.dates().stream()
+                                            .map(date -> SuitableEvent.ConvertedDates.builder()
+                                                    .start(DateParser.toLocalDate(date.start()))
+                                                    .end(DateParser.toLocalDate(date.end())).build())
+                                            .filter(convertedDates -> {
+                                                LocalDate from;
+                                                LocalDate to;
+                                                from = Objects.requireNonNullElseGet(dateFrom, LocalDate::now);
+                                                to = Objects.requireNonNullElseGet(dateTo, () -> LocalDate.now().plusWeeks(1));
+
+                                                return convertedDates.start().isAfter(from) && convertedDates.end().isBefore(to);
+                                            })
+                                            .toList())
+                                    .build())
+                            .toList());
+        } catch (InterruptedException e) {
+            log.error("Interrupted exception", e);
+            throw new GeneralException("Interrupted exception");
+        } finally {
+            semaphore.release();
+        }
+    }
+}

--- a/KudaGo/src/main/java/arden/java/kudago/service/impl/SuitableEventServiceReactiveImpl.java
+++ b/KudaGo/src/main/java/arden/java/kudago/service/impl/SuitableEventServiceReactiveImpl.java
@@ -3,10 +3,10 @@ package arden.java.kudago.service.impl;
 import arden.java.kudago.client.CurrencyRestTemplate;
 import arden.java.kudago.client.EventRestTemplate;
 import arden.java.kudago.dto.request.CurrencyConvertRequest;
-import arden.java.kudago.dto.response.event.Event;
+import arden.java.kudago.dto.response.event.SuitableEvent;
 import arden.java.kudago.dto.response.event.EventResponse;
 import arden.java.kudago.exception.GeneralException;
-import arden.java.kudago.service.EventService;
+import arden.java.kudago.service.SuitableEventService;
 import arden.java.kudago.utils.DateParser;
 import arden.java.kudago.utils.PriceParser;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +22,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-public class EventServiceReactiveImpl implements EventService<Mono<List<EventResponse>>, Mono<List<Event>>> {
+public class SuitableEventServiceReactiveImpl implements SuitableEventService<Mono<List<EventResponse>>, Mono<List<SuitableEvent>>> {
     private final EventRestTemplate eventRestTemplate;
     private final CurrencyRestTemplate currencyRestTemplate;
 
@@ -41,7 +41,7 @@ public class EventServiceReactiveImpl implements EventService<Mono<List<EventRes
     }
 
     @Override
-    public Mono<List<Event>> getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo) {
+    public Mono<List<SuitableEvent>> getSuitableEvents(Double budget, String currency, LocalDate dateFrom, LocalDate dateTo) {
         Mono<List<EventResponse>> eventsMono = getEvents(dateFrom, dateTo);
         Mono<Double> convertedPriceMono = Mono.just(currencyRestTemplate.convertPrice(CurrencyConvertRequest.builder()
                         .fromCurrency(currency)
@@ -58,7 +58,7 @@ public class EventServiceReactiveImpl implements EventService<Mono<List<EventRes
                     return Flux.fromIterable(events)
                             .filter(event -> PriceParser.parseEventPrice(event.price()) <= price)
                             .sort(Comparator.comparing(EventResponse::favoritesCount).reversed())
-                            .map(event -> Event.builder()
+                            .map(event -> SuitableEvent.builder()
                                     .id(event.id())
                                     .title(event.title())
                                     .siteUrl(event.siteUrl())
@@ -66,7 +66,7 @@ public class EventServiceReactiveImpl implements EventService<Mono<List<EventRes
                                     .favoritesCount(event.favoritesCount())
                                     .price(!PriceParser.parseEventPrice(event.price()).equals(0D) ? PriceParser.parseEventPrice(event.price()).toString() : "бесплатно")
                                     .dates(event.dates().stream()
-                                            .map(date -> Event.ConvertedDates.builder()
+                                            .map(date -> SuitableEvent.ConvertedDates.builder()
                                                     .start(DateParser.toLocalDate(date.start()))
                                                     .end(DateParser.toLocalDate(date.end())).build())
                                             .filter(convertedDates -> {

--- a/KudaGo/src/main/java/arden/java/kudago/start/StartupLogic.java
+++ b/KudaGo/src/main/java/arden/java/kudago/start/StartupLogic.java
@@ -1,4 +1,4 @@
-package arden.java.kudago.event;
+package arden.java.kudago.start;
 
 import arden.java.kudago.client.CategoryRestTemplate;
 import arden.java.kudago.client.LocationRestTemplate;

--- a/KudaGo/src/main/java/arden/java/kudago/start/StartupLogic.java
+++ b/KudaGo/src/main/java/arden/java/kudago/start/StartupLogic.java
@@ -2,8 +2,8 @@ package arden.java.kudago.start;
 
 import arden.java.kudago.client.CategoryRestTemplate;
 import arden.java.kudago.client.LocationRestTemplate;
-import arden.java.kudago.dto.response.places.CategoryResponse;
-import arden.java.kudago.dto.response.places.LocationResponse;
+import arden.java.kudago.dto.response.places.CategoryDto;
+import arden.java.kudago.dto.response.places.LocationDto;
 import arden.java.kudago.exception.GeneralException;
 import arden.java.kudago.repository.StorageRepository;
 import configuration.annotation.logtimexec.LogTimeExec;
@@ -34,8 +34,8 @@ import java.util.concurrent.TimeUnit;
 public class StartupLogic implements ApplicationContextAware {
     private final CategoryRestTemplate categoryRestTemplate;
     private final LocationRestTemplate locationRestTemplate;
-    private final StorageRepository<Long, CategoryResponse> categoryRepository;
-    private final StorageRepository<String, LocationResponse> locationStorage;
+    private final StorageRepository<Long, CategoryDto> categoryRepository;
+    private final StorageRepository<String, LocationDto> locationStorage;
     @Qualifier("fixedThreadPool")
     private final ExecutorService fixedThreadPool;
     @Qualifier("scheduledThreadPool")
@@ -72,9 +72,9 @@ public class StartupLogic implements ApplicationContextAware {
     }
 
     public String fillDBWithCategories() {
-        Optional<List<CategoryResponse>> request = categoryRestTemplate.getAllCategories();
+        Optional<List<CategoryDto>> request = categoryRestTemplate.getAllCategories();
         if (request.isPresent()) {
-            List<CategoryResponse> categories = request.get();
+            List<CategoryDto> categories = request.get();
             categories.forEach(category -> categoryRepository.create(category.id(), category));
             log.info("All categories are updated and saved to DB");
 
@@ -86,13 +86,13 @@ public class StartupLogic implements ApplicationContextAware {
     }
 
     public String fillDBWithLocations() {
-        Optional<List<LocationResponse>> request = locationRestTemplate.getLocations();
+        Optional<List<LocationDto>> request = locationRestTemplate.getLocations();
         if (request.isPresent()) {
-            List<LocationResponse> locationResponses = request.get();
-            locationResponses.forEach(location -> locationStorage.create(location.slug(), location));
+            List<LocationDto> locationRespons = request.get();
+            locationRespons.forEach(location -> locationStorage.create(location.slug(), location));
             log.info("All locations are updated and saved to DB");
 
-            return locationResponses.toString();
+            return locationRespons.toString();
         } else {
             log.error("Problems with saving locations to DB");
             throw new GeneralException("No locations found");

--- a/KudaGo/src/main/java/arden/java/kudago/start/StartupLogic.java
+++ b/KudaGo/src/main/java/arden/java/kudago/start/StartupLogic.java
@@ -2,8 +2,8 @@ package arden.java.kudago.start;
 
 import arden.java.kudago.client.CategoryRestTemplate;
 import arden.java.kudago.client.LocationRestTemplate;
-import arden.java.kudago.dto.response.places.Category;
-import arden.java.kudago.dto.response.places.Location;
+import arden.java.kudago.dto.response.places.CategoryResponse;
+import arden.java.kudago.dto.response.places.LocationResponse;
 import arden.java.kudago.exception.GeneralException;
 import arden.java.kudago.repository.StorageRepository;
 import configuration.annotation.logtimexec.LogTimeExec;
@@ -34,8 +34,8 @@ import java.util.concurrent.TimeUnit;
 public class StartupLogic implements ApplicationContextAware {
     private final CategoryRestTemplate categoryRestTemplate;
     private final LocationRestTemplate locationRestTemplate;
-    private final StorageRepository<Long, Category> categoryRepository;
-    private final StorageRepository<String, Location> locationStorage;
+    private final StorageRepository<Long, CategoryResponse> categoryRepository;
+    private final StorageRepository<String, LocationResponse> locationStorage;
     @Qualifier("fixedThreadPool")
     private final ExecutorService fixedThreadPool;
     @Qualifier("scheduledThreadPool")
@@ -72,9 +72,9 @@ public class StartupLogic implements ApplicationContextAware {
     }
 
     public String fillDBWithCategories() {
-        Optional<List<Category>> request = categoryRestTemplate.getAllCategories();
+        Optional<List<CategoryResponse>> request = categoryRestTemplate.getAllCategories();
         if (request.isPresent()) {
-            List<Category> categories = request.get();
+            List<CategoryResponse> categories = request.get();
             categories.forEach(category -> categoryRepository.create(category.id(), category));
             log.info("All categories are updated and saved to DB");
 
@@ -86,13 +86,13 @@ public class StartupLogic implements ApplicationContextAware {
     }
 
     public String fillDBWithLocations() {
-        Optional<List<Location>> request = locationRestTemplate.getLocations();
+        Optional<List<LocationResponse>> request = locationRestTemplate.getLocations();
         if (request.isPresent()) {
-            List<Location> locations = request.get();
-            locations.forEach(location -> locationStorage.create(location.slug(), location));
+            List<LocationResponse> locationResponses = request.get();
+            locationResponses.forEach(location -> locationStorage.create(location.slug(), location));
             log.info("All locations are updated and saved to DB");
 
-            return locations.toString();
+            return locationResponses.toString();
         } else {
             log.error("Problems with saving locations to DB");
             throw new GeneralException("No locations found");

--- a/KudaGo/src/main/java/arden/java/kudago/start/StartupLogic.java
+++ b/KudaGo/src/main/java/arden/java/kudago/start/StartupLogic.java
@@ -2,6 +2,7 @@ package arden.java.kudago.start;
 
 import arden.java.kudago.client.CategoryRestTemplate;
 import arden.java.kudago.client.LocationRestTemplate;
+import arden.java.kudago.config.ThreadsConfig;
 import arden.java.kudago.dto.response.places.CategoryDto;
 import arden.java.kudago.dto.response.places.LocationDto;
 import arden.java.kudago.exception.GeneralException;
@@ -19,7 +20,6 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -40,8 +40,7 @@ public class StartupLogic implements ApplicationContextAware {
     private final ExecutorService fixedThreadPool;
     @Qualifier("scheduledThreadPool")
     private final ScheduledExecutorService scheduledExecutorService;
-    private final Duration period;
-    private final Duration delay;
+    private final ThreadsConfig threadsConfig;
     private ApplicationContext applicationContext;
 
     @Override
@@ -52,7 +51,7 @@ public class StartupLogic implements ApplicationContextAware {
     @EventListener(ApplicationReadyEvent.class)
     public void startup() {
         log.info("Starting up, preparing to initialize DB with data");
-        scheduledExecutorService.scheduleAtFixedRate(this::fillDB, delay.toSeconds(), period.toSeconds(), TimeUnit.SECONDS);
+        scheduledExecutorService.scheduleAtFixedRate(this::fillDB, threadsConfig.delayInSeconds().toSeconds(), threadsConfig.periodInSeconds().toSeconds(), TimeUnit.SECONDS);
     }
 
     public void fillDB() {

--- a/KudaGo/src/main/java/arden/java/kudago/utils/DateParser.java
+++ b/KudaGo/src/main/java/arden/java/kudago/utils/DateParser.java
@@ -1,0 +1,19 @@
+package arden.java.kudago.utils;
+
+import lombok.experimental.UtilityClass;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+@UtilityClass
+public class DateParser {
+    public LocalDate toLocalDate(Long date) {
+        return Instant.ofEpochSecond(date).atZone(ZoneOffset.UTC).toLocalDate();
+    }
+
+    public long toEpochSeconds(LocalDate date) {
+        return date.atStartOfDay(ZoneId.systemDefault()).toEpochSecond();
+    }
+}

--- a/KudaGo/src/main/java/arden/java/kudago/utils/PriceParser.java
+++ b/KudaGo/src/main/java/arden/java/kudago/utils/PriceParser.java
@@ -1,0 +1,16 @@
+package arden.java.kudago.utils;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@UtilityClass
+public class PriceParser {
+    public Double parseEventPrice(String event) {
+        Pattern pattern = Pattern.compile("\\d+");
+        Matcher matcher = pattern.matcher(event);
+
+        return matcher.find() ? Double.parseDouble(matcher.group()) : 0D;
+    }
+}

--- a/KudaGo/src/main/resources/application.yaml
+++ b/KudaGo/src/main/resources/application.yaml
@@ -1,6 +1,16 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   application:
     name: KudaGo
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${HOST}/${DB_NAME}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  liquibase:
+    enabled: true
+    change-log: db/changelog/changelog-master.yaml
 
 base-config:
   kuda-go-url: https://kudago.com/public-api/v1.4/

--- a/KudaGo/src/main/resources/application.yaml
+++ b/KudaGo/src/main/resources/application.yaml
@@ -11,6 +11,22 @@ spring:
   liquibase:
     enabled: true
     change-log: db/changelog/changelog-master.yaml
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        session:
+          events:
+            log:
+              LOG_QUERIES_SLOWER_THAN_MS: 25
+        show_sql: true
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: warn
 
 base-config:
   kuda-go-url: https://kudago.com/public-api/v1.4/

--- a/KudaGo/src/main/resources/application.yaml
+++ b/KudaGo/src/main/resources/application.yaml
@@ -7,10 +7,9 @@ base-config:
   currency-url: http://localhost:8080/api/v1/currencies
 
 multithreading:
-  fixed-pool-size: 20
-  scheduled-pool-size: 10
+  threads-num: 1
   period-in-seconds: 5
-  delay-in-seconds: 3
+  delay-in-seconds: 0
   max-num-of-threads: 3
 
 server:

--- a/KudaGo/src/main/resources/application.yaml
+++ b/KudaGo/src/main/resources/application.yaml
@@ -11,6 +11,7 @@ multithreading:
   scheduled-pool-size: 10
   period-in-seconds: 5
   delay-in-seconds: 3
+  max-num-of-threads: 3
 
 server:
   port: 8081

--- a/KudaGo/src/main/resources/application.yaml
+++ b/KudaGo/src/main/resources/application.yaml
@@ -3,10 +3,14 @@ spring:
     name: KudaGo
 
 base-config:
-  url: https://kudago.com/public-api/v1.4/
+  kuda-go-url: https://kudago.com/public-api/v1.4/
+  currency-url: http://localhost:8080/api/v1/currencies
 
 multithreading:
   fixed-pool-size: 20
   scheduled-pool-size: 10
   period-in-seconds: 5
   delay-in-seconds: 3
+
+server:
+  port: 8081

--- a/KudaGo/src/main/resources/application.yaml
+++ b/KudaGo/src/main/resources/application.yaml
@@ -8,8 +8,8 @@ base-config:
 
 multithreading:
   threads-num: 1
-  period-in-seconds: 5
-  delay-in-seconds: 0
+  period-in-seconds: PT5S
+  delay-in-seconds: PT0S
   max-num-of-threads: 3
 
 server:

--- a/KudaGo/src/main/resources/application.yaml
+++ b/KudaGo/src/main/resources/application.yaml
@@ -4,3 +4,9 @@ spring:
 
 base-config:
   url: https://kudago.com/public-api/v1.4/
+
+multithreading:
+  fixed-pool-size: 20
+  scheduled-pool-size: 10
+  period-in-seconds: 5
+  delay-in-seconds: 3

--- a/KudaGo/src/main/resources/application.yaml
+++ b/KudaGo/src/main/resources/application.yaml
@@ -9,7 +9,7 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASSWORD}
   liquibase:
-    enabled: true
+    enabled: false
     change-log: db/changelog/changelog-master.yaml
   jpa:
     hibernate:

--- a/KudaGo/src/main/resources/db/changelog/changelog-1.0.sql
+++ b/KudaGo/src/main/resources/db/changelog/changelog-1.0.sql
@@ -1,14 +1,14 @@
-CREATE TABLE IF NOT EXISTS locations
+CREATE TABLE IF NOT EXISTS locationResponses
 (
     id   BIGSERIAL PRIMARY KEY,
     slug VARCHAR(128) NOT NULL,
     name VARCHAR(128) NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS events
+CREATE TABLE IF NOT EXISTS suitableEvents
 (
     id       BIGSERIAL PRIMARY KEY,
     name     VARCHAR(128)             NOT NULL,
     date     TIMESTAMP WITH TIME ZONE NOT NULL,
-    location_id BIGINT REFERENCES locations (id) ON DELETE CASCADE
+    location_id BIGINT REFERENCES locationResponses (id) ON DELETE CASCADE
 );

--- a/KudaGo/src/main/resources/db/changelog/changelog-1.0.sql
+++ b/KudaGo/src/main/resources/db/changelog/changelog-1.0.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS locations
+(
+    id   BIGSERIAL PRIMARY KEY,
+    slug VARCHAR(128) NOT NULL,
+    name VARCHAR(128) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS events
+(
+    id       BIGSERIAL PRIMARY KEY,
+    name     VARCHAR(128)             NOT NULL,
+    date     TIMESTAMP WITH TIME ZONE NOT NULL,
+    place_id BIGINT REFERENCES locations (id) ON DELETE CASCADE
+);

--- a/KudaGo/src/main/resources/db/changelog/changelog-1.0.sql
+++ b/KudaGo/src/main/resources/db/changelog/changelog-1.0.sql
@@ -1,14 +1,14 @@
-CREATE TABLE IF NOT EXISTS locationResponses
+CREATE TABLE IF NOT EXISTS locations
 (
     id   BIGSERIAL PRIMARY KEY,
     slug VARCHAR(128) NOT NULL,
     name VARCHAR(128) NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS suitableEvents
+CREATE TABLE IF NOT EXISTS events
 (
     id       BIGSERIAL PRIMARY KEY,
     name     VARCHAR(128)             NOT NULL,
     date     TIMESTAMP WITH TIME ZONE NOT NULL,
-    location_id BIGINT REFERENCES locationResponses (id) ON DELETE CASCADE
+    location_id BIGINT REFERENCES locations (id) ON DELETE CASCADE
 );

--- a/KudaGo/src/main/resources/db/changelog/changelog-1.0.sql
+++ b/KudaGo/src/main/resources/db/changelog/changelog-1.0.sql
@@ -12,3 +12,6 @@ CREATE TABLE IF NOT EXISTS events
     date     TIMESTAMP WITH TIME ZONE NOT NULL,
     location_id BIGINT REFERENCES locations (id) ON DELETE CASCADE
 );
+
+-- rollback DROP TABLE locations
+-- rollback DROP TABLE events

--- a/KudaGo/src/main/resources/db/changelog/changelog-1.0.sql
+++ b/KudaGo/src/main/resources/db/changelog/changelog-1.0.sql
@@ -10,5 +10,5 @@ CREATE TABLE IF NOT EXISTS events
     id       BIGSERIAL PRIMARY KEY,
     name     VARCHAR(128)             NOT NULL,
     date     TIMESTAMP WITH TIME ZONE NOT NULL,
-    place_id BIGINT REFERENCES locations (id) ON DELETE CASCADE
+    location_id BIGINT REFERENCES locations (id) ON DELETE CASCADE
 );

--- a/KudaGo/src/main/resources/db/changelog/changelog-master.yaml
+++ b/KudaGo/src/main/resources/db/changelog/changelog-master.yaml
@@ -1,0 +1,3 @@
+databaseChangeLog:
+  - include:
+      file: classpath:db/changelog/changelog-1.0.sql

--- a/KudaGo/src/main/resources/db/changelog/changelog-master.yaml
+++ b/KudaGo/src/main/resources/db/changelog/changelog-master.yaml
@@ -1,3 +1,3 @@
 databaseChangeLog:
   - include:
-      file: classpath:db/changelog/changelog-1.0.sql
+      file: changelog-1.0.sql

--- a/KudaGo/src/test/java/arden/java/kudago/client/CategoryRestTemplateTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/client/CategoryRestTemplateTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.client;
 
-import arden.java.kudago.dto.response.places.CategoryResponse;
+import arden.java.kudago.dto.response.places.CategoryDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,7 +33,7 @@ public class CategoryRestTemplateTest {
 
     @Test
     public void testGetAllCategories() {
-        Optional<List<CategoryResponse>> categories = categoryRestTemplate.getAllCategories();
+        Optional<List<CategoryDto>> categories = categoryRestTemplate.getAllCategories();
 
         assertAll("Check response",
                 () -> assertThat(categories.isPresent()).isTrue(),

--- a/KudaGo/src/test/java/arden/java/kudago/client/CategoryRestTemplateTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/client/CategoryRestTemplateTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.client;
 
-import arden.java.kudago.dto.response.places.Category;
+import arden.java.kudago.dto.response.places.CategoryResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,7 +33,7 @@ public class CategoryRestTemplateTest {
 
     @Test
     public void testGetAllCategories() {
-        Optional<List<Category>> categories = categoryRestTemplate.getAllCategories();
+        Optional<List<CategoryResponse>> categories = categoryRestTemplate.getAllCategories();
 
         assertAll("Check response",
                 () -> assertThat(categories.isPresent()).isTrue(),

--- a/KudaGo/src/test/java/arden/java/kudago/client/CurrencyRestTemplateTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/client/CurrencyRestTemplateTest.java
@@ -1,0 +1,45 @@
+package arden.java.kudago.client;
+
+import arden.java.kudago.dto.request.CurrencyConvertRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.wiremock.integrations.testcontainers.WireMockContainer;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+@Testcontainers
+public class CurrencyRestTemplateTest {
+    @Autowired
+    private CurrencyRestTemplate currencyRestTemplate;
+
+    @Container
+    public static WireMockContainer wiremockServer = new WireMockContainer("wiremock/wiremock:3.6.0")
+            .withMappingFromResource("currency-stub.json");
+
+    @DynamicPropertySource
+    public static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("base-config.currency-url", wiremockServer::getBaseUrl);
+    }
+
+    @Test
+    public void testConvertPrice_SuccessTest() {
+        Optional<Double> currency = currencyRestTemplate.convertPrice(CurrencyConvertRequest.builder()
+                .fromCurrency("USD")
+                .toCurrency("RUB")
+                .amount(100D)
+                .build());
+
+        assertAll("Check response",
+                () -> assertThat(currency.isPresent()).isTrue(),
+                () -> assertThat(currency.get()).isEqualTo(10000D));
+    }
+}

--- a/KudaGo/src/test/java/arden/java/kudago/client/EventRestTemplateTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/client/EventRestTemplateTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.client;
 
-import arden.java.kudago.dto.response.places.Category;
+import arden.java.kudago.dto.response.event.EventResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,13 +18,13 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
 @Testcontainers
-public class CategoryRestTemplateTest {
+public class EventRestTemplateTest {
     @Autowired
-    private CategoryRestTemplate categoryRestTemplate;
+    private EventRestTemplate eventRestTemplate;
 
     @Container
     public static WireMockContainer wiremockServer = new WireMockContainer("wiremock/wiremock:3.6.0")
-            .withMappingFromResource("kudago-stub.json");
+            .withMappingFromResource("events-stub.json");
 
     @DynamicPropertySource
     public static void configureProperties(DynamicPropertyRegistry registry) {
@@ -32,13 +32,13 @@ public class CategoryRestTemplateTest {
     }
 
     @Test
-    public void testGetAllCategories() {
-        Optional<List<Category>> categories = categoryRestTemplate.getAllCategories();
+    public void testGetAllEvents_SuccessTest() {
+        Optional<List<EventResponse>> events = eventRestTemplate.getEvents(1727740800, 1730419199);
 
         assertAll("Check response",
-                () -> assertThat(categories.isPresent()).isTrue(),
-                () -> assertThat(categories.get().size()).isEqualTo(2),
-                () -> assertThat(categories.get().getFirst().id()).isEqualTo(1L),
-                () -> assertThat(categories.get().getFirst().name()).isEqualTo("Магазин здорового питания"));
+                () -> assertThat(events.isPresent()).isTrue(),
+                () -> assertThat(events.get().size()).isEqualTo(2),
+                () -> assertThat(events.get().getFirst().id()).isEqualTo(1L),
+                () -> assertThat(events.get().getFirst().title()).isEqualTo("Фестиваль осени"));
     }
 }

--- a/KudaGo/src/test/java/arden/java/kudago/client/LocationRestTemplateTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/client/LocationRestTemplateTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.client;
 
-import arden.java.kudago.dto.Location;
+import arden.java.kudago.dto.response.places.Location;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,7 +28,7 @@ public class LocationRestTemplateTest {
 
     @DynamicPropertySource
     public static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("base-config.url", wiremockServer::getBaseUrl);
+        registry.add("base-config.kuda-go-url", wiremockServer::getBaseUrl);
     }
 
     @Test

--- a/KudaGo/src/test/java/arden/java/kudago/client/LocationRestTemplateTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/client/LocationRestTemplateTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.client;
 
-import arden.java.kudago.dto.response.places.Location;
+import arden.java.kudago.dto.response.places.LocationResponse;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,7 +33,7 @@ public class LocationRestTemplateTest {
 
     @Test
     public void testGetAllLocations() {
-        Optional<List<Location>> locations = locationRestTemplate.getLocations();
+        Optional<List<LocationResponse>> locations = locationRestTemplate.getLocations();
 
         assertAll("Check response",
                 () -> assertThat(locations.isPresent()).isTrue(),

--- a/KudaGo/src/test/java/arden/java/kudago/client/LocationRestTemplateTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/client/LocationRestTemplateTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.client;
 
-import arden.java.kudago.dto.response.places.LocationResponse;
+import arden.java.kudago.dto.response.places.LocationDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -33,7 +33,7 @@ public class LocationRestTemplateTest {
 
     @Test
     public void testGetAllLocations() {
-        Optional<List<LocationResponse>> locations = locationRestTemplate.getLocations();
+        Optional<List<LocationDto>> locations = locationRestTemplate.getLocations();
 
         assertAll("Check response",
                 () -> assertThat(locations.isPresent()).isTrue(),

--- a/KudaGo/src/test/java/arden/java/kudago/client/SuitableEventRestTemplateTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/client/SuitableEventRestTemplateTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
 @Testcontainers
-public class EventRestTemplateTest {
+public class SuitableEventRestTemplateTest {
     @Autowired
     private EventRestTemplate eventRestTemplate;
 

--- a/KudaGo/src/test/java/arden/java/kudago/controller/CategoryControllerTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/controller/CategoryControllerTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.response.places.Category;
+import arden.java.kudago.dto.response.places.CategoryResponse;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.service.CategoryService;
@@ -38,9 +38,9 @@ public class CategoryControllerTest {
 
     @Test
     void testGetCategoriesSuccess() throws Exception {
-        List<Category> categories = List.of(
-                new Category(1L, "cafe", "Кафе быстрого питания"),
-                new Category(2L, "shop", "Магазин одежды")
+        List<CategoryResponse> categories = List.of(
+                new CategoryResponse(1L, "cafe", "Кафе быстрого питания"),
+                new CategoryResponse(2L, "shop", "Магазин одежды")
         );
 
         when(categoryService.getAllCategories()).thenReturn(categories);
@@ -54,8 +54,8 @@ public class CategoryControllerTest {
 
     @Test
     void testGetCategoryByIdSuccess() throws Exception {
-        Category category = new Category(1L, "cafe", "Кафе быстрого питания");
-        when(categoryService.getCategoryById(1L)).thenReturn(category);
+        CategoryResponse categoryResponse = new CategoryResponse(1L, "cafe", "Кафе быстрого питания");
+        when(categoryService.getCategoryById(1L)).thenReturn(categoryResponse);
 
         mockMvc.perform(get("/api/v1/places/categories/1"))
                 .andExpect(status().isOk())
@@ -73,14 +73,14 @@ public class CategoryControllerTest {
 
     @Test
     void testCreateCategorySuccess() throws Exception {
-        Category newCategory = new Category(null, "museum", "Музей воды");
-        Category createdCategory = new Category(1L, "museum", "Музей воды");
+        CategoryResponse newCategoryResponse = new CategoryResponse(null, "museum", "Музей воды");
+        CategoryResponse createdCategoryResponse = new CategoryResponse(1L, "museum", "Музей воды");
 
-        when(categoryService.createCategory(any(Category.class))).thenReturn(createdCategory);
+        when(categoryService.createCategory(any(CategoryResponse.class))).thenReturn(createdCategoryResponse);
 
         mockMvc.perform(post("/api/v1/places/categories")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(newCategory)))
+                        .content(objectMapper.writeValueAsString(newCategoryResponse)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").value(1))
@@ -89,24 +89,24 @@ public class CategoryControllerTest {
 
     @Test
     void testCreateCategoryInvalidData() throws Exception {
-        Category invalidCategory = new Category(null, "", "");
-        when(categoryService.createCategory(any(Category.class))).thenThrow(new CreationObjectException("Can't create an object"));
+        CategoryResponse invalidCategoryResponse = new CategoryResponse(null, "", "");
+        when(categoryService.createCategory(any(CategoryResponse.class))).thenThrow(new CreationObjectException("Can't create an object"));
 
         mockMvc.perform(post("/api/v1/places/categories")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidCategory)))
+                        .content(objectMapper.writeValueAsString(invalidCategoryResponse)))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void testUpdateCategorySuccess() throws Exception {
-        Category updatedCategory = new Category(1L, "restaurant", "Restaurant");
+        CategoryResponse updatedCategoryResponse = new CategoryResponse(1L, "restaurant", "Restaurant");
 
-        when(categoryService.updateCategory(anyLong(), any(Category.class))).thenReturn(updatedCategory);
+        when(categoryService.updateCategory(anyLong(), any(CategoryResponse.class))).thenReturn(updatedCategoryResponse);
 
         mockMvc.perform(put("/api/v1/places/categories/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updatedCategory)))
+                        .content(objectMapper.writeValueAsString(updatedCategoryResponse)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.slug").value("restaurant"));
@@ -114,12 +114,12 @@ public class CategoryControllerTest {
 
     @Test
     void testUpdateCategoryNotFound() throws Exception {
-        when(categoryService.updateCategory(anyLong(), any(Category.class)))
+        when(categoryService.updateCategory(anyLong(), any(CategoryResponse.class)))
                 .thenThrow(new IdNotFoundException("Category not found"));
 
         mockMvc.perform(put("/api/v1/places/categories/999")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new Category(999L, "unknown", "Unknown"))))
+                        .content(objectMapper.writeValueAsString(new CategoryResponse(999L, "unknown", "Unknown"))))
                 .andExpect(status().isNotFound());
     }
 

--- a/KudaGo/src/test/java/arden/java/kudago/controller/CategoryControllerTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/controller/CategoryControllerTest.java
@@ -1,11 +1,10 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.response.places.CategoryResponse;
+import arden.java.kudago.dto.response.places.CategoryDto;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.service.CategoryService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -29,18 +28,14 @@ public class CategoryControllerTest {
     @MockBean
     private CategoryService categoryService;
 
+    @Autowired
     private ObjectMapper objectMapper;
-
-    @BeforeEach
-    void setup() {
-        objectMapper = new ObjectMapper();
-    }
 
     @Test
     void testGetCategoriesSuccess() throws Exception {
-        List<CategoryResponse> categories = List.of(
-                new CategoryResponse(1L, "cafe", "Кафе быстрого питания"),
-                new CategoryResponse(2L, "shop", "Магазин одежды")
+        List<CategoryDto> categories = List.of(
+                new CategoryDto(1L, "cafe", "Кафе быстрого питания"),
+                new CategoryDto(2L, "shop", "Магазин одежды")
         );
 
         when(categoryService.getAllCategories()).thenReturn(categories);
@@ -54,8 +49,8 @@ public class CategoryControllerTest {
 
     @Test
     void testGetCategoryByIdSuccess() throws Exception {
-        CategoryResponse categoryResponse = new CategoryResponse(1L, "cafe", "Кафе быстрого питания");
-        when(categoryService.getCategoryById(1L)).thenReturn(categoryResponse);
+        CategoryDto categoryDto = new CategoryDto(1L, "cafe", "Кафе быстрого питания");
+        when(categoryService.getCategoryById(1L)).thenReturn(categoryDto);
 
         mockMvc.perform(get("/api/v1/places/categories/1"))
                 .andExpect(status().isOk())
@@ -73,14 +68,14 @@ public class CategoryControllerTest {
 
     @Test
     void testCreateCategorySuccess() throws Exception {
-        CategoryResponse newCategoryResponse = new CategoryResponse(null, "museum", "Музей воды");
-        CategoryResponse createdCategoryResponse = new CategoryResponse(1L, "museum", "Музей воды");
+        CategoryDto newCategoryDto = new CategoryDto(null, "museum", "Музей воды");
+        CategoryDto createdCategoryDto = new CategoryDto(1L, "museum", "Музей воды");
 
-        when(categoryService.createCategory(any(CategoryResponse.class))).thenReturn(createdCategoryResponse);
+        when(categoryService.createCategory(any(CategoryDto.class))).thenReturn(createdCategoryDto);
 
         mockMvc.perform(post("/api/v1/places/categories")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(newCategoryResponse)))
+                        .content(objectMapper.writeValueAsString(newCategoryDto)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.id").value(1))
@@ -89,24 +84,24 @@ public class CategoryControllerTest {
 
     @Test
     void testCreateCategoryInvalidData() throws Exception {
-        CategoryResponse invalidCategoryResponse = new CategoryResponse(null, "", "");
-        when(categoryService.createCategory(any(CategoryResponse.class))).thenThrow(new CreationObjectException("Can't create an object"));
+        CategoryDto invalidCategoryDto = new CategoryDto(null, "", "");
+        when(categoryService.createCategory(any(CategoryDto.class))).thenThrow(new CreationObjectException("Can't create an object"));
 
         mockMvc.perform(post("/api/v1/places/categories")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidCategoryResponse)))
+                        .content(objectMapper.writeValueAsString(invalidCategoryDto)))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void testUpdateCategorySuccess() throws Exception {
-        CategoryResponse updatedCategoryResponse = new CategoryResponse(1L, "restaurant", "Restaurant");
+        CategoryDto updatedCategoryDto = new CategoryDto(1L, "restaurant", "Restaurant");
 
-        when(categoryService.updateCategory(anyLong(), any(CategoryResponse.class))).thenReturn(updatedCategoryResponse);
+        when(categoryService.updateCategory(anyLong(), any(CategoryDto.class))).thenReturn(updatedCategoryDto);
 
         mockMvc.perform(put("/api/v1/places/categories/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updatedCategoryResponse)))
+                        .content(objectMapper.writeValueAsString(updatedCategoryDto)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.slug").value("restaurant"));
@@ -114,12 +109,12 @@ public class CategoryControllerTest {
 
     @Test
     void testUpdateCategoryNotFound() throws Exception {
-        when(categoryService.updateCategory(anyLong(), any(CategoryResponse.class)))
+        when(categoryService.updateCategory(anyLong(), any(CategoryDto.class)))
                 .thenThrow(new IdNotFoundException("Category not found"));
 
         mockMvc.perform(put("/api/v1/places/categories/999")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new CategoryResponse(999L, "unknown", "Unknown"))))
+                        .content(objectMapper.writeValueAsString(new CategoryDto(999L, "unknown", "Unknown"))))
                 .andExpect(status().isNotFound());
     }
 

--- a/KudaGo/src/test/java/arden/java/kudago/controller/CategoryControllerTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/controller/CategoryControllerTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.Category;
+import arden.java.kudago.dto.response.places.Category;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.service.CategoryService;

--- a/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
@@ -1,8 +1,17 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.response.event.Event;
+import arden.java.kudago.dto.response.event.EventDto;
 import arden.java.kudago.dto.response.event.EventResponse;
+import arden.java.kudago.dto.response.event.SuitableEvent;
+import arden.java.kudago.exception.CreationObjectException;
+import arden.java.kudago.exception.IdNotFoundException;
+import arden.java.kudago.model.Location;
 import arden.java.kudago.service.EventService;
+import arden.java.kudago.service.SuitableEventService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -12,26 +21,162 @@ import org.springframework.test.web.servlet.MockMvc;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest({EventController.class})
 public class EventControllerTest {
     @Autowired
-    private MockMvc mvc;
+    private MockMvc mockMvc;
 
     @MockBean
-    private EventService<Mono<List<EventResponse>>, Mono<List<Event>>> eventService;
+    private SuitableEventService<Mono<List<EventResponse>>, Mono<List<SuitableEvent>>> suitableEventService;
+
+    @MockBean
+    private EventService eventService;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setup() {
+        objectMapper = new ObjectMapper();
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.registerModule(new JavaTimeModule());
+    }
 
     @Test
     void testGetEventsSuccess() throws Exception {
-        Mono<List<Event>> events = Mono.just(
+        List<EventDto> events = List.of(
+                new EventDto("Party", OffsetDateTime.now(), new Location()),
+                new EventDto("Concert", OffsetDateTime.now(), new Location())
+        );
+
+        when(eventService.getAllEvents()).thenReturn(events);
+
+        mockMvc.perform(get("/api/v1/events/list"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.size()").value(2))
+                .andExpect(jsonPath("$[0].name").value("Party"));
+    }
+
+    @Test
+    void testGetEventByIdSuccess() throws Exception {
+        EventDto eventDto = new EventDto("Party", OffsetDateTime.now(), new Location());
+        when(eventService.getEventById(1L)).thenReturn(eventDto);
+
+        mockMvc.perform(get("/api/v1/events/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.name").value("Party"));
+    }
+
+    @Test
+    void testGetEventBySlugNotFound() throws Exception {
+        when(eventService.getEventById(anyLong())).thenThrow(new IdNotFoundException("Event not found"));
+
+        mockMvc.perform(get("/api/v1/events/999"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testCreateEventSuccess() throws Exception {
+        EventDto newEvent = new EventDto("Party", OffsetDateTime.now(), new Location());
+
+        when(eventService.createEvent(any(EventDto.class))).thenReturn(newEvent);
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newEvent)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.name").value("Party"));
+    }
+
+    @Test
+    void testCreateEventInvalidData() throws Exception {
+        EventDto invalidEventResponse = new EventDto(null, OffsetDateTime.now(), new Location());
+        when(eventService.createEvent(any(EventDto.class))).thenThrow(new CreationObjectException("Can't create an object"));
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidEventResponse)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testUpdateEventSuccess() throws Exception {
+        EventDto updatedEvent = new EventDto("Party", OffsetDateTime.now(), new Location());
+
+        when(eventService.updateEvent(anyLong(), any(EventDto.class))).thenReturn(updatedEvent);
+
+        mockMvc.perform(put("/api/v1/events/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedEvent)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.name").value("Party"));
+    }
+
+    @Test
+    void testUpdateEventNotFound() throws Exception {
+        when(eventService.updateEvent(anyLong(), any(EventDto.class)))
+                .thenThrow(new IdNotFoundException("Event not found"));
+
+        mockMvc.perform(put("/api/v1/events/999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new EventDto("Party", OffsetDateTime.now(), new Location()))))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testDeleteEventSuccess() throws Exception {
+        doNothing().when(eventService).deleteEvent(1L);
+
+        mockMvc.perform(delete("/api/v1/events/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().string("true"));
+    }
+
+    @Test
+    void testDeleteEventNotFound() throws Exception {
+        doThrow(new IdNotFoundException("Event not found")).when(eventService).deleteEvent(anyLong());
+
+        mockMvc.perform(delete("/api/v1/events/999"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testFilterByName() throws Exception {
+        List<EventDto> events = List.of(
+                new EventDto("Party", OffsetDateTime.now(), new Location()),
+                new EventDto("Concert", OffsetDateTime.now(), new Location())
+        );
+
+        when(eventService.getEventsByFilter("Party", null, null, null)).thenReturn(List.of(events.getFirst()));
+
+        mockMvc.perform(get("/api/v1/events/filter")
+                .param("name", "Party"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.size()").value(1))
+                .andExpect(jsonPath("$[0].name").value("Party"));
+
+    }
+
+    @Test
+    void testGetSuitableEventsSuccess() throws Exception {
+        Mono<List<SuitableEvent>> events = Mono.just(
                 List.of(
-                        new Event(1L,
-                                List.of(new Event.ConvertedDates(LocalDate.now(), LocalDate.now().plusWeeks(1))),
+                        new SuitableEvent(1L,
+                                List.of(new SuitableEvent.ConvertedDates(LocalDate.now(), LocalDate.now().plusWeeks(1))),
                                 "Фестиваль осени",
                                 "Какой-то классный фестиваль",
                                 "https://festival.ru",
@@ -40,9 +185,9 @@ public class EventControllerTest {
                 )
         );
 
-        when(eventService.getSuitableEvents(100D, "USD", null, null)).thenReturn(events);
+        when(suitableEventService.getSuitableEvents(100D, "USD", null, null)).thenReturn(events);
 
-        mvc.perform(get("/api/v1/events")
+        mockMvc.perform(get("/api/v1/events/suitable")
                         .param("budget", "100")
                         .param("currency", "USD")
                         .param("amount", "400.0"))

--- a/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
@@ -1,0 +1,53 @@
+package arden.java.kudago.controller;
+
+import arden.java.kudago.dto.response.event.Event;
+import arden.java.kudago.service.EventService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest({EventController.class})
+public class EventControllerTest {
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private EventService eventService;
+
+    @Test
+    void testGetEventsSuccess() throws Exception {
+        CompletableFuture<List<Event>> events = CompletableFuture.completedFuture(
+                List.of(
+                        new Event(1L,
+                                List.of(new Event.ConvertedDates(LocalDate.now(), LocalDate.now().plusWeeks(1))),
+                                "Фестиваль осени",
+                                "Какой-то классный фестиваль",
+                                "https://festival.ru",
+                                "400.0",
+                                30L)
+                )
+        );
+
+        when(eventService.getSuitableEvents(100D, "USD", null, null)).thenReturn(events);
+
+        mvc.perform(get("/api/v1/events")
+                        .param("budget", "100")
+                        .param("currency", "USD")
+                        .param("amount", "400.0"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.size()").value(1))
+                .andExpect(jsonPath("$[0].title").value("Фестиваль осени"));
+    }
+}

--- a/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
@@ -13,9 +13,13 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import reactor.core.publisher.Mono;
@@ -57,13 +61,15 @@ public class EventControllerTest {
                 new EventDto("Concert", OffsetDateTime.now(), new Location())
         );
 
-        when(eventService.getAllEvents()).thenReturn(events);
+        Page<EventDto> eventPage = new PageImpl<>(events, PageRequest.of(0, events.size()), events.size());
+        when(eventService.getAllEvents(ArgumentMatchers.any())).thenReturn(eventPage);
 
-        mockMvc.perform(get("/api/v1/events/list"))
+        mockMvc.perform(get("/api/v1/events/list")
+                        .param("size", "2"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.size()").value(2))
-                .andExpect(jsonPath("$[0].name").value("Party"));
+                .andExpect(jsonPath("$.content.size()").value(2))
+                .andExpect(jsonPath("$.content[0].name").value("Party"));
     }
 
     @Test

--- a/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
@@ -1,6 +1,7 @@
 package arden.java.kudago.controller;
 
 import arden.java.kudago.dto.response.event.Event;
+import arden.java.kudago.dto.response.event.EventResponse;
 import arden.java.kudago.service.EventService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,10 +9,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -23,11 +24,11 @@ public class EventControllerTest {
     private MockMvc mvc;
 
     @MockBean
-    private EventService eventService;
+    private EventService<Mono<List<EventResponse>>, Mono<List<Event>>> eventService;
 
     @Test
     void testGetEventsSuccess() throws Exception {
-        CompletableFuture<List<Event>> events = CompletableFuture.completedFuture(
+        Mono<List<Event>> events = Mono.just(
                 List.of(
                         new Event(1L,
                                 List.of(new Event.ConvertedDates(LocalDate.now(), LocalDate.now().plusWeeks(1))),

--- a/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
@@ -9,12 +9,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.asyncDispatch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -42,13 +44,16 @@ public class EventControllerTest {
 
         when(eventService.getSuitableEvents(100D, "USD", null, null)).thenReturn(events);
 
-        mvc.perform(get("/api/v1/events")
+        MvcResult result = mvc.perform(get("/api/v1/events")
                         .param("budget", "100")
                         .param("currency", "USD")
                         .param("amount", "400.0"))
                 .andExpect(status().isOk())
+                .andReturn();
+
+        mvc.perform(asyncDispatch(result))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.size()").value(1))
+                .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].title").value("Фестиваль осени"));
     }
 }

--- a/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/controller/EventControllerTest.java
@@ -5,7 +5,6 @@ import arden.java.kudago.dto.response.event.EventResponse;
 import arden.java.kudago.dto.response.event.SuitableEvent;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
-import arden.java.kudago.model.Location;
 import arden.java.kudago.service.EventService;
 import arden.java.kudago.service.SuitableEventService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -57,8 +56,8 @@ public class EventControllerTest {
     @Test
     void testGetEventsSuccess() throws Exception {
         List<EventDto> events = List.of(
-                new EventDto("Party", OffsetDateTime.now(), new Location()),
-                new EventDto("Concert", OffsetDateTime.now(), new Location())
+                new EventDto("Party", OffsetDateTime.now(), 1L),
+                new EventDto("Concert", OffsetDateTime.now(), 1L)
         );
 
         Page<EventDto> eventPage = new PageImpl<>(events, PageRequest.of(0, events.size()), events.size());
@@ -74,7 +73,7 @@ public class EventControllerTest {
 
     @Test
     void testGetEventByIdSuccess() throws Exception {
-        EventDto eventDto = new EventDto("Party", OffsetDateTime.now(), new Location());
+        EventDto eventDto = new EventDto("Party", OffsetDateTime.now(), 1L);
         when(eventService.getEventById(1L)).thenReturn(eventDto);
 
         mockMvc.perform(get("/api/v1/events/1"))
@@ -93,7 +92,7 @@ public class EventControllerTest {
 
     @Test
     void testCreateEventSuccess() throws Exception {
-        EventDto newEvent = new EventDto("Party", OffsetDateTime.now(), new Location());
+        EventDto newEvent = new EventDto("Party", OffsetDateTime.now(), 1L);
 
         when(eventService.createEvent(any(EventDto.class))).thenReturn(newEvent);
 
@@ -107,7 +106,7 @@ public class EventControllerTest {
 
     @Test
     void testCreateEventInvalidData() throws Exception {
-        EventDto invalidEventResponse = new EventDto(null, OffsetDateTime.now(), new Location());
+        EventDto invalidEventResponse = new EventDto(null, OffsetDateTime.now(), 1L);
         when(eventService.createEvent(any(EventDto.class))).thenThrow(new CreationObjectException("Can't create an object"));
 
         mockMvc.perform(post("/api/v1/events")
@@ -118,7 +117,7 @@ public class EventControllerTest {
 
     @Test
     void testUpdateEventSuccess() throws Exception {
-        EventDto updatedEvent = new EventDto("Party", OffsetDateTime.now(), new Location());
+        EventDto updatedEvent = new EventDto("Party", OffsetDateTime.now(), 1L);
 
         when(eventService.updateEvent(anyLong(), any(EventDto.class))).thenReturn(updatedEvent);
 
@@ -137,7 +136,7 @@ public class EventControllerTest {
 
         mockMvc.perform(put("/api/v1/events/999")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new EventDto("Party", OffsetDateTime.now(), new Location()))))
+                        .content(objectMapper.writeValueAsString(new EventDto("Party", OffsetDateTime.now(), 1L))))
                 .andExpect(status().isNotFound());
     }
 
@@ -162,18 +161,19 @@ public class EventControllerTest {
     @Test
     void testFilterByName() throws Exception {
         List<EventDto> events = List.of(
-                new EventDto("Party", OffsetDateTime.now(), new Location()),
-                new EventDto("Concert", OffsetDateTime.now(), new Location())
+                new EventDto("Party", OffsetDateTime.now(), 1L),
+                new EventDto("Concert", OffsetDateTime.now(), 1L)
         );
 
-        when(eventService.getEventsByFilter("Party", null, null, null)).thenReturn(List.of(events.getFirst()));
+        Page<EventDto> eventPage = new PageImpl<>(List.of(events.getFirst()), PageRequest.of(0, 1), 1);
+        when(eventService.getEventsByFilter(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(eventPage);
 
         mockMvc.perform(get("/api/v1/events/filter")
-                .param("name", "Party"))
+                        .param("name", "Party"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.size()").value(1))
-                .andExpect(jsonPath("$[0].name").value("Party"));
+                .andExpect(jsonPath("$.content.size()").value(1))
+                .andExpect(jsonPath("$.content[0].name").value("Party"));
 
     }
 

--- a/KudaGo/src/test/java/arden/java/kudago/controller/LocationControllerTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/controller/LocationControllerTest.java
@@ -1,11 +1,10 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.response.places.LocationResponse;
+import arden.java.kudago.dto.response.places.LocationDto;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.service.LocationService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -15,35 +14,31 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(LocationController.class)
 public class LocationControllerTest {
     @Autowired
     private MockMvc mockMvc;
-    
+
     @MockBean
     private LocationService locationService;
 
+    @Autowired
     private ObjectMapper objectMapper;
-
-    @BeforeEach
-    void setup() {
-        objectMapper = new ObjectMapper();
-    }
 
     @Test
     void testGetLocationsSuccess() throws Exception {
-        List<LocationResponse> locationResponses = List.of(
-                new LocationResponse("spb",  "Кафе быстрого питания"),
-                new LocationResponse("ekb",  "Магазин одежды")
+        List<LocationDto> locationResponse = List.of(
+                new LocationDto("spb", "Кафе быстрого питания"),
+                new LocationDto("ekb", "Магазин одежды")
         );
 
-        when(locationService.getAllLocations()).thenReturn(locationResponses);
+        when(locationService.getAllLocations()).thenReturn(locationResponse);
 
         mockMvc.perform(get("/api/v1/locations"))
                 .andExpect(status().isOk())
@@ -54,8 +49,8 @@ public class LocationControllerTest {
 
     @Test
     void testGetLocationBySlugSuccess() throws Exception {
-        LocationResponse LocationResponse = new LocationResponse("spb",  "Кафе быстрого питания");
-        when(locationService.getLocationById(1L)).thenReturn(LocationResponse);
+        LocationDto LocationDto = new LocationDto("spb", "Кафе быстрого питания");
+        when(locationService.getLocationById(1L)).thenReturn(LocationDto);
 
         mockMvc.perform(get("/api/v1/locations/1"))
                 .andExpect(status().isOk())
@@ -73,13 +68,13 @@ public class LocationControllerTest {
 
     @Test
     void testCreateLocationSuccess() throws Exception {
-        LocationResponse createdLocationResponse = new LocationResponse("spb", "Музей воды");
+        LocationDto createdLocationDto = new LocationDto("spb", "Музей воды");
 
-        when(locationService.createLocation(any(LocationResponse.class))).thenReturn(createdLocationResponse);
+        when(locationService.createLocation(any(LocationDto.class))).thenReturn(createdLocationDto);
 
         mockMvc.perform(post("/api/v1/locations")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(createdLocationResponse)))
+                        .content(objectMapper.writeValueAsString(createdLocationDto)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.slug").value("spb"));
@@ -87,24 +82,24 @@ public class LocationControllerTest {
 
     @Test
     void testCreateLocationInvalidData() throws Exception {
-        LocationResponse invalidLocationResponse = new LocationResponse(null, "");
-        when(locationService.createLocation(any(LocationResponse.class))).thenThrow(new CreationObjectException("Can't create an object"));
+        LocationDto invalidLocationDto = new LocationDto(null, "");
+        when(locationService.createLocation(any(LocationDto.class))).thenThrow(new CreationObjectException("Can't create an object"));
 
         mockMvc.perform(post("/api/v1/locations")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidLocationResponse)))
+                        .content(objectMapper.writeValueAsString(invalidLocationDto)))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void testUpdateLocationSuccess() throws Exception {
-        LocationResponse updatedLocationResponse = new LocationResponse("spb",  "Restaurant");
+        LocationDto updatedLocationDto = new LocationDto("spb", "Restaurant");
 
-        when(locationService.updateLocation(anyLong(), any(LocationResponse.class))).thenReturn(updatedLocationResponse);
+        when(locationService.updateLocation(anyLong(), any(LocationDto.class))).thenReturn(updatedLocationDto);
 
         mockMvc.perform(put("/api/v1/locations/1")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(updatedLocationResponse)))
+                        .content(objectMapper.writeValueAsString(updatedLocationDto)))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.slug").value("spb"));
@@ -112,12 +107,12 @@ public class LocationControllerTest {
 
     @Test
     void testUpdateLocationNotFound() throws Exception {
-        when(locationService.updateLocation(anyLong(), any(LocationResponse.class)))
+        when(locationService.updateLocation(anyLong(), any(LocationDto.class)))
                 .thenThrow(new IdNotFoundException("Location not found"));
 
         mockMvc.perform(put("/api/v1/locations/999")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(new LocationResponse("gfg", "Unknown"))))
+                        .content(objectMapper.writeValueAsString(new LocationDto("gfg", "Unknown"))))
                 .andExpect(status().isNotFound());
     }
 

--- a/KudaGo/src/test/java/arden/java/kudago/controller/LocationControllerTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/controller/LocationControllerTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.controller;
 
-import arden.java.kudago.dto.Location;
+import arden.java.kudago.dto.response.places.Location;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.service.LocationService;

--- a/KudaGo/src/test/java/arden/java/kudago/e2e/EventE2ETest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/e2e/EventE2ETest.java
@@ -1,0 +1,148 @@
+package arden.java.kudago.e2e;
+
+import arden.java.kudago.dto.response.event.EventDto;
+import arden.java.kudago.model.Location;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.validation.constraints.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.OffsetDateTime;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+@Transactional
+public class EventE2ETest {
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(DockerImageName.parse("postgres:latest"))
+            .withDatabaseName("test-location")
+            .withUsername("test-location")
+            .withPassword("test-location");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @DynamicPropertySource
+    static void jpaProperties(@NotNull DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+
+    @BeforeEach
+    void setUp() {
+        entityManager.createNativeQuery("TRUNCATE TABLE events RESTART IDENTITY CASCADE").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE TABLE locations RESTART IDENTITY CASCADE").executeUpdate();
+    }
+
+    @Test
+    void createAndUpdate_shouldCreateAndRetrieveEvent() throws Exception {
+        EventDto eventDto = new EventDto("event", OffsetDateTime.parse("2024-10-23T15:30:00+01:00"), new Location());
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(eventDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("event"))
+                .andExpect(jsonPath("$.date").value("2024-10-23T14:30:00Z"));
+
+        mockMvc.perform(get("/api/v1/events/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("event"))
+                .andExpect(jsonPath("$.date").value("2024-10-23T14:30:00Z"));
+    }
+
+    @Test
+    void shouldUpdateEvent() throws Exception {
+        EventDto eventDto = new EventDto("event", OffsetDateTime.parse("2024-10-23T15:30:00+01:00"), new Location());
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(eventDto)))
+                .andExpect(status().isOk());
+
+        EventDto updatedEventDto = new EventDto("event-updated", OffsetDateTime.parse("2024-10-23T15:30:00+01:00"), new Location());
+        mockMvc.perform(put("/api/v1/events/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedEventDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("event-updated"))
+                .andExpect(jsonPath("$.date").value("2024-10-23T14:30:00Z"));
+
+        mockMvc.perform(get("/api/v1/events/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("event-updated"))
+                .andExpect(jsonPath("$.date").value("2024-10-23T14:30:00Z"));
+    }
+
+    @Test
+    void getAllEventsByFilter_shouldReturnFilteredEvents() throws Exception {
+        EventDto eventDto1 = new EventDto("Art Exhibition", OffsetDateTime.parse("2024-10-23T15:30:00+01:00"), null);
+        EventDto eventDto2 = new EventDto("Music Concert", OffsetDateTime.parse("2024-10-24T19:00:00+01:00"), null);
+        EventDto eventDto3 = new EventDto("Theater Play", OffsetDateTime.parse("2024-10-25T20:00:00+01:00"), null);
+
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(eventDto1)))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(eventDto2)))
+                .andExpect(status().isOk());
+        mockMvc.perform(post("/api/v1/events")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(eventDto3)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/events/filter")
+                        .param("name", "Art Exhibition"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].name").value("Art Exhibition"));
+
+
+        mockMvc.perform(get("/api/v1/events/filter")
+                        .param("location", "Some Location"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+
+        OffsetDateTime fromDate = OffsetDateTime.parse("2024-10-23T00:00:00+01:00");
+        OffsetDateTime toDate = OffsetDateTime.parse("2024-10-24T23:59:59+01:00");
+        mockMvc.perform(get("/api/v1/events/filter")
+                        .param("fromDate", fromDate.toString())
+                        .param("toDate", toDate.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].name").value("Art Exhibition"))
+                .andExpect(jsonPath("$[1].name").value("Music Concert"));
+    }
+
+}

--- a/KudaGo/src/test/java/arden/java/kudago/e2e/LocationE2ETest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/e2e/LocationE2ETest.java
@@ -31,9 +31,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class LocationE2ETest {
     @Container
     private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(DockerImageName.parse("postgres:latest"))
-            .withDatabaseName("test-location")
-            .withUsername("test-location")
-            .withPassword("test-location");
+            .withDatabaseName("test-locationDto")
+            .withUsername("test-locationDto")
+            .withPassword("test-locationDto");
 
     @Autowired
     private MockMvc mockMvc;

--- a/KudaGo/src/test/java/arden/java/kudago/e2e/LocationE2ETest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/e2e/LocationE2ETest.java
@@ -1,0 +1,100 @@
+package arden.java.kudago.e2e;
+
+import arden.java.kudago.dto.response.places.LocationDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.validation.constraints.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+@Transactional
+public class LocationE2ETest {
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(DockerImageName.parse("postgres:latest"))
+            .withDatabaseName("test-location")
+            .withUsername("test-location")
+            .withPassword("test-location");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @DynamicPropertySource
+    static void jpaProperties(@NotNull DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+
+    @BeforeEach
+    void setUp() {
+        entityManager.createNativeQuery("TRUNCATE TABLE locations RESTART IDENTITY CASCADE").executeUpdate();
+    }
+
+    @Test
+    void createAndUpdate_shouldCreateAndRetrieveLocation() throws Exception {
+        LocationDto newLocation = new LocationDto("slug-1", "Location 1");
+
+        mockMvc.perform(post("/api/v1/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newLocation)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.slug").value("slug-1"))
+                .andExpect(jsonPath("$.name").value("Location 1"));
+
+        mockMvc.perform(get("/api/v1/locations/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.slug").value("slug-1"))
+                .andExpect(jsonPath("$.name").value("Location 1"));
+    }
+
+    @Test
+    void shouldUpdateLocation() throws Exception {
+        LocationDto newLocation = new LocationDto("slug-2", "Location 2");
+
+        mockMvc.perform(post("/api/v1/locations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newLocation)))
+                .andExpect(status().isOk());
+
+        LocationDto updatedLocation = new LocationDto("updated-slug", "Updated Location");
+        mockMvc.perform(put("/api/v1/locations/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedLocation)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.slug").value("updated-slug"))
+                .andExpect(jsonPath("$.name").value("Updated Location"));
+
+        mockMvc.perform(get("/api/v1/locations/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.slug").value("updated-slug"))
+                .andExpect(jsonPath("$.name").value("Updated Location"));
+    }
+}

--- a/KudaGo/src/test/java/arden/java/kudago/repository/EventRepositoryTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/repository/EventRepositoryTest.java
@@ -1,0 +1,119 @@
+package arden.java.kudago.repository;
+
+import arden.java.kudago.model.Event;
+import arden.java.kudago.model.Location;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.validation.constraints.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Testcontainers
+@Transactional
+public class EventRepositoryTest {
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES = new PostgreSQLContainer<>(DockerImageName.parse("postgres:latest"))
+            .withDatabaseName("test")
+            .withUsername("test")
+            .withPassword("test");
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private LocationRepository locationRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @DynamicPropertySource
+    static void jpaProperties(@NotNull DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+
+    @BeforeEach
+    void setUp() {
+        entityManager.createNativeQuery("TRUNCATE TABLE locations RESTART IDENTITY CASCADE").executeUpdate();
+        entityManager.createNativeQuery("TRUNCATE TABLE events RESTART IDENTITY CASCADE").executeUpdate();
+
+        Location location = new Location();
+        location.setName("Test Location");
+        location.setSlug("test-location");
+        locationRepository.save(location);
+
+        Event event1 = new Event();
+        event1.setName("Party");
+        event1.setDate(OffsetDateTime.parse("2024-10-23T15:30:00+01:00"));
+        event1.setLocation(location);
+        eventRepository.save(event1);
+
+        Event event2 = new Event();
+        event2.setName("Concert");
+        event2.setDate(OffsetDateTime.parse("2024-10-21T15:30:00+01:00"));
+        event2.setLocation(location);
+        eventRepository.save(event2);
+    }
+
+    @Test
+    @DisplayName("Find all events from the list")
+    void testFindAllEvents() {
+        List<Event> events = eventRepository.findAll();
+        assertThat(events).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Filter events by name")
+    void testFindByName() {
+        Specification<Event> spec = EventRepository.buildSpecification("Party", null, null, null);
+        List<Event> events = eventRepository.findAll(spec);
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst().getName()).isEqualTo("Party");
+    }
+
+    @Test
+    @DisplayName("Filter events by date")
+    void testFilterByDate() {
+        Specification<Event> spec = EventRepository.buildSpecification(null, null,
+                OffsetDateTime.parse("2024-10-22T15:30:00+01:00"),
+                OffsetDateTime.parse("2024-10-24T15:30:00+01:00"));
+        List<Event> events = eventRepository.findAll(spec);
+        assertThat(events).hasSize(1);
+        assertThat(events.getFirst().getName()).isEqualTo("Party");
+    }
+
+    @Test
+    @DisplayName("Filter events by location")
+    void testFindByLocation() {
+        Specification<Event> spec = EventRepository.buildSpecification(null, "Test Location", null, null);
+        List<Event> events = eventRepository.findAll(spec);
+        assertThat(events).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("Empty list in case of filter mismatch")
+    void testEmptyList() {
+        Specification<Event> spec = EventRepository.buildSpecification("?", null, null, null);
+        List<Event> events = eventRepository.findAll(spec);
+        assertThat(events).hasSize(0);
+    }
+}
+

--- a/KudaGo/src/test/java/arden/java/kudago/service/CategoryServiceTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/CategoryServiceTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.Category;
+import arden.java.kudago.dto.response.places.Category;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.repository.StorageRepository;

--- a/KudaGo/src/test/java/arden/java/kudago/service/CategoryServiceTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/CategoryServiceTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.response.places.Category;
+import arden.java.kudago.dto.response.places.CategoryResponse;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.repository.StorageRepository;
@@ -22,13 +22,13 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class CategoryServiceTest {
     @Mock
-    private StorageRepository<Long, Category> storage;
+    private StorageRepository<Long, CategoryResponse> storage;
     @InjectMocks
     private CategoryServiceImpl categoryService;
 
-    private final List<Category> categoriesList = List.of(
-            new Category(1L, "shop", "Магазин здорового питания"),
-            new Category(2L, "cafe", "Кафе быстрого питания")
+    private final List<CategoryResponse> categoriesList = List.of(
+            new CategoryResponse(1L, "shop", "Магазин здорового питания"),
+            new CategoryResponse(2L, "cafe", "Кафе быстрого питания")
     );
 
     @Test
@@ -38,7 +38,7 @@ public class CategoryServiceTest {
         when(storage.readAll()).thenReturn(categoriesList);
 
         //Act
-        List<Category> categories = categoryService.getAllCategories();
+        List<CategoryResponse> categories = categoryService.getAllCategories();
 
         //Assert
         assertThat(categories).isEqualTo(categoriesList);
@@ -49,7 +49,7 @@ public class CategoryServiceTest {
     public void getAllCategories_failTest() {
         when(storage.readAll()).thenReturn(Collections.emptyList());
 
-        List<Category> categories = categoryService.getAllCategories();
+        List<CategoryResponse> categories = categoryService.getAllCategories();
 
         assertThat(Collections.emptyList()).isEqualTo(categories);
     }
@@ -59,9 +59,9 @@ public class CategoryServiceTest {
     public void getCategoryById_successTest() {
         when(storage.read(1L)).thenReturn(categoriesList.getFirst());
 
-        Category category = categoryService.getCategoryById(1L);
+        CategoryResponse categoryResponse = categoryService.getCategoryById(1L);
 
-        assertThat(category).isEqualTo(categoriesList.getFirst());
+        assertThat(categoryResponse).isEqualTo(categoriesList.getFirst());
     }
 
     @Test
@@ -77,9 +77,9 @@ public class CategoryServiceTest {
     public void createCategory_successTest() {
         when(storage.create(1L, categoriesList.getFirst())).thenReturn(categoriesList.getFirst());
 
-        Category category = categoryService.createCategory(categoriesList.getFirst());
+        CategoryResponse categoryResponse = categoryService.createCategory(categoriesList.getFirst());
 
-        assertThat(category).isEqualTo(categoriesList.getFirst());
+        assertThat(categoryResponse).isEqualTo(categoriesList.getFirst());
     }
 
     @Test
@@ -96,9 +96,9 @@ public class CategoryServiceTest {
         when(storage.update(1L, categoriesList.getLast())).thenReturn(categoriesList.getLast());
         when(storage.read(1L)).thenReturn(categoriesList.getFirst());
 
-        Category category = categoryService.updateCategory(1L, categoriesList.getLast());
+        CategoryResponse categoryResponse = categoryService.updateCategory(1L, categoriesList.getLast());
 
-        assertThat(category).isEqualTo(categoriesList.getLast());
+        assertThat(categoryResponse).isEqualTo(categoriesList.getLast());
     }
 
     @Test

--- a/KudaGo/src/test/java/arden/java/kudago/service/CategoryServiceTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/CategoryServiceTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.response.places.CategoryResponse;
+import arden.java.kudago.dto.response.places.CategoryDto;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.repository.StorageRepository;
@@ -22,13 +22,13 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 public class CategoryServiceTest {
     @Mock
-    private StorageRepository<Long, CategoryResponse> storage;
+    private StorageRepository<Long, CategoryDto> storage;
     @InjectMocks
     private CategoryServiceImpl categoryService;
 
-    private final List<CategoryResponse> categoriesList = List.of(
-            new CategoryResponse(1L, "shop", "Магазин здорового питания"),
-            new CategoryResponse(2L, "cafe", "Кафе быстрого питания")
+    private final List<CategoryDto> categoriesList = List.of(
+            new CategoryDto(1L, "shop", "Магазин здорового питания"),
+            new CategoryDto(2L, "cafe", "Кафе быстрого питания")
     );
 
     @Test
@@ -38,7 +38,7 @@ public class CategoryServiceTest {
         when(storage.readAll()).thenReturn(categoriesList);
 
         //Act
-        List<CategoryResponse> categories = categoryService.getAllCategories();
+        List<CategoryDto> categories = categoryService.getAllCategories();
 
         //Assert
         assertThat(categories).isEqualTo(categoriesList);
@@ -49,7 +49,7 @@ public class CategoryServiceTest {
     public void getAllCategories_failTest() {
         when(storage.readAll()).thenReturn(Collections.emptyList());
 
-        List<CategoryResponse> categories = categoryService.getAllCategories();
+        List<CategoryDto> categories = categoryService.getAllCategories();
 
         assertThat(Collections.emptyList()).isEqualTo(categories);
     }
@@ -59,9 +59,9 @@ public class CategoryServiceTest {
     public void getCategoryById_successTest() {
         when(storage.read(1L)).thenReturn(categoriesList.getFirst());
 
-        CategoryResponse categoryResponse = categoryService.getCategoryById(1L);
+        CategoryDto categoryDto = categoryService.getCategoryById(1L);
 
-        assertThat(categoryResponse).isEqualTo(categoriesList.getFirst());
+        assertThat(categoryDto).isEqualTo(categoriesList.getFirst());
     }
 
     @Test
@@ -77,9 +77,9 @@ public class CategoryServiceTest {
     public void createCategory_successTest() {
         when(storage.create(1L, categoriesList.getFirst())).thenReturn(categoriesList.getFirst());
 
-        CategoryResponse categoryResponse = categoryService.createCategory(categoriesList.getFirst());
+        CategoryDto categoryDto = categoryService.createCategory(categoriesList.getFirst());
 
-        assertThat(categoryResponse).isEqualTo(categoriesList.getFirst());
+        assertThat(categoryDto).isEqualTo(categoriesList.getFirst());
     }
 
     @Test
@@ -96,9 +96,9 @@ public class CategoryServiceTest {
         when(storage.update(1L, categoriesList.getLast())).thenReturn(categoriesList.getLast());
         when(storage.read(1L)).thenReturn(categoriesList.getFirst());
 
-        CategoryResponse categoryResponse = categoryService.updateCategory(1L, categoriesList.getLast());
+        CategoryDto categoryDto = categoryService.updateCategory(1L, categoriesList.getLast());
 
-        assertThat(categoryResponse).isEqualTo(categoriesList.getLast());
+        assertThat(categoryDto).isEqualTo(categoriesList.getLast());
     }
 
     @Test

--- a/KudaGo/src/test/java/arden/java/kudago/service/EventServiceReactiveTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/EventServiceReactiveTest.java
@@ -18,8 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -36,12 +34,8 @@ public class EventServiceReactiveTest {
     @Mock
     private EventRestTemplate eventRestTemplate;
 
-    @Mock
-    private ExecutorService executorService;
-
     @BeforeEach
     void setUp() {
-        executorService = Executors.newFixedThreadPool(10);
         eventService = new EventServiceReactiveImpl(eventRestTemplate, currencyRestTemplate);
     }
 
@@ -81,7 +75,7 @@ public class EventServiceReactiveTest {
         when(currencyRestTemplate.convertPrice(currencyConvertRequest)).thenReturn(Optional.of(1000D));
         List<Event> events = eventService.getSuitableEvents(100D, "USD", start, end).block();
 
-        assertAll("Check respoonse",
+        assertAll("Check response",
                 () -> assertThat(events.size()).isEqualTo(1),
                 () -> assertThat(events.getFirst().id()).isEqualTo(1L));
     }

--- a/KudaGo/src/test/java/arden/java/kudago/service/EventServiceReactiveTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/EventServiceReactiveTest.java
@@ -3,9 +3,9 @@ package arden.java.kudago.service;
 import arden.java.kudago.client.CurrencyRestTemplate;
 import arden.java.kudago.client.EventRestTemplate;
 import arden.java.kudago.dto.request.CurrencyConvertRequest;
-import arden.java.kudago.dto.response.event.EventResponse;
 import arden.java.kudago.dto.response.event.Event;
-import arden.java.kudago.service.impl.EventServiceImpl;
+import arden.java.kudago.dto.response.event.EventResponse;
+import arden.java.kudago.service.impl.EventServiceReactiveImpl;
 import arden.java.kudago.utils.DateParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,9 +26,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class EventServiceTest {
+public class EventServiceReactiveTest {
     @InjectMocks
-    private EventServiceImpl eventService;
+    private EventServiceReactiveImpl eventService;
 
     @Mock
     private CurrencyRestTemplate currencyRestTemplate;
@@ -42,7 +42,7 @@ public class EventServiceTest {
     @BeforeEach
     void setUp() {
         executorService = Executors.newFixedThreadPool(10);
-        eventService = new EventServiceImpl(eventRestTemplate, currencyRestTemplate, executorService);
+        eventService = new EventServiceReactiveImpl(eventRestTemplate, currencyRestTemplate);
     }
 
     @Test
@@ -79,7 +79,7 @@ public class EventServiceTest {
                 unsuitableEventResponse
         )));
         when(currencyRestTemplate.convertPrice(currencyConvertRequest)).thenReturn(Optional.of(1000D));
-        List<Event> events = eventService.getSuitableEvents(100D, "USD", start, end).join();
+        List<Event> events = eventService.getSuitableEvents(100D, "USD", start, end).block();
 
         assertAll("Check respoonse",
                 () -> assertThat(events.size()).isEqualTo(1),
@@ -110,7 +110,7 @@ public class EventServiceTest {
                 eventResponse
         )));
         when(currencyRestTemplate.convertPrice(currencyConvertRequest)).thenReturn(Optional.of(1000D));
-        List<Event> events = eventService.getSuitableEvents(100D, "USD", null, null).join();
+        List<Event> events = eventService.getSuitableEvents(100D, "USD", null, null).block();
 
         assertAll("Check response",
                 () -> assertThat(events.size()).isEqualTo(1),

--- a/KudaGo/src/test/java/arden/java/kudago/service/EventServiceTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/EventServiceTest.java
@@ -13,6 +13,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -47,23 +51,23 @@ public class EventServiceTest {
     @DisplayName("Getting all Events: success test")
     public void getAllEvents_successTest() {
         //Arrange
-        when(eventRepository.findAll()).thenReturn(events.stream().map(Optional::get).toList());
+        when(eventRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(events.stream().map(Optional::get).toList(), PageRequest.of(0, events.size()), events.size()));
 
         //Act
-        List<EventDto> EventDto = eventService.getAllEvents();
+        Page<EventDto> result = eventService.getAllEvents(PageRequest.of(0, eventsList.size()));
 
-        //Assert
-        assertThat(EventDto).isEqualTo(eventsList);
+        // Assert
+        assertThat(result.getContent()).isEqualTo(eventsList);
     }
 
     @Test
     @DisplayName("Getting all Events: fail test")
     public void getAllEvents_failTest() {
-        when(eventRepository.findAll()).thenReturn(Collections.emptyList());
+        when(eventRepository.findAll(any(Pageable.class))).thenReturn(Page.empty());
 
-        List<EventDto> EventDto = eventService.getAllEvents();
+        Page<EventDto> eventDtos = eventService.getAllEvents(PageRequest.of(0, eventsList.size()));
 
-        assertThat(Collections.emptyList()).isEqualTo(EventDto);
+        assertThat(Collections.emptyList()).isEqualTo(eventDtos.getContent());
     }
 
     @Test

--- a/KudaGo/src/test/java/arden/java/kudago/service/EventServiceTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/EventServiceTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -42,7 +43,7 @@ public class EventServiceTest {
     @BeforeEach
     void setUp() {
         executorService = Executors.newFixedThreadPool(10);
-        eventService = new EventServiceImpl(eventRestTemplate, currencyRestTemplate, executorService);
+        eventService = new EventServiceImpl(eventRestTemplate, currencyRestTemplate, new Semaphore(3), executorService);
     }
 
     @Test
@@ -81,7 +82,7 @@ public class EventServiceTest {
         when(currencyRestTemplate.convertPrice(currencyConvertRequest)).thenReturn(Optional.of(1000D));
         List<Event> events = eventService.getSuitableEvents(100D, "USD", start, end).join();
 
-        assertAll("Check respoonse",
+        assertAll("Check response",
                 () -> assertThat(events.size()).isEqualTo(1),
                 () -> assertThat(events.getFirst().id()).isEqualTo(1L));
     }

--- a/KudaGo/src/test/java/arden/java/kudago/service/EventServiceTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/EventServiceTest.java
@@ -1,0 +1,119 @@
+package arden.java.kudago.service;
+
+import arden.java.kudago.client.CurrencyRestTemplate;
+import arden.java.kudago.client.EventRestTemplate;
+import arden.java.kudago.dto.request.CurrencyConvertRequest;
+import arden.java.kudago.dto.response.event.EventResponse;
+import arden.java.kudago.dto.response.event.Event;
+import arden.java.kudago.service.impl.EventServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class EventServiceTest {
+    @InjectMocks
+    private EventServiceImpl eventService;
+
+    @Mock
+    private CurrencyRestTemplate currencyRestTemplate;
+
+    @Mock
+    private EventRestTemplate eventRestTemplate;
+
+    @Mock
+    private ExecutorService executorService;
+
+    @BeforeEach
+    void setUp() {
+        executorService = Executors.newFixedThreadPool(10);
+        eventService = new EventServiceImpl(eventRestTemplate, currencyRestTemplate, executorService);
+    }
+
+    @Test
+    @DisplayName("Только одно из двух мероприятий подходит по цене")
+    void getSuitableEvents_differentPrices_successTest() {
+        CurrencyConvertRequest currencyConvertRequest = CurrencyConvertRequest.builder()
+                .fromCurrency("USD")
+                .toCurrency("RUB")
+                .amount(100D)
+                .build();
+        EventResponse suitableEventResponse = EventResponse.builder()
+                .id(1L)
+                .dates(List.of(new EventResponse.Dates(1727740800L, 1738368000L))) // от 01.10.24 до 01.02.25
+                .title("Фестиваль осени")
+                .description("Какой-то классный фестиваль")
+                .siteUrl("https://festival.ru")
+                .price("400.0")
+                .favoritesCount(30L)
+                .build();
+        EventResponse unsuitableEventResponse = EventResponse.builder()
+                .id(2L)
+                .dates(List.of(new EventResponse.Dates(1727740800L, 1738368000L))) // от 01.10.24 до 01.02.25
+                .title("Очень дорогое")
+                .description("Ну очень дорогое")
+                .siteUrl("https://expensive.ru")
+                .price("40000000.0")
+                .favoritesCount(30L)
+                .build();
+        LocalDate start = LocalDate.of(2024, 10, 1);
+        LocalDate end = LocalDate.of(2025, 3, 1);
+
+        when(eventRestTemplate.getEvents(eventService.toEpochSeconds(start), eventService.toEpochSeconds(end))).thenReturn(Optional.of(List.of(
+                suitableEventResponse,
+                unsuitableEventResponse
+        )));
+        when(currencyRestTemplate.convertPrice(currencyConvertRequest)).thenReturn(Optional.of(1000D));
+        List<Event> events = eventService.getSuitableEvents(100D, "USD", start, end).join();
+
+        assertAll("Check respoonse",
+                () -> assertThat(events.size()).isEqualTo(1),
+                () -> assertThat(events.getFirst().id()).isEqualTo(1L));
+    }
+
+    @Test
+    @DisplayName("Дата не указана")
+    void getSuitableEvents_differentDates_successTest() {
+        CurrencyConvertRequest currencyConvertRequest = CurrencyConvertRequest.builder()
+                .fromCurrency("USD")
+                .toCurrency("RUB")
+                .amount(100D)
+                .build();
+        EventResponse eventResponse = EventResponse.builder()
+                .id(1L)
+                .dates(List.of(new EventResponse.Dates(1727740800L, 1738368000L))) // от 01.10.24 до 01.02.25
+                .title("Выставка")
+                .description("Бесплатная выставка")
+                .siteUrl("https://free.ru")
+                .price("0.0")
+                .favoritesCount(30L)
+                .build();
+
+        LocalDate start = LocalDate.now();
+        LocalDate end = LocalDate.now().plusWeeks(1);
+        when(eventRestTemplate.getEvents(eventService.toEpochSeconds(start), eventService.toEpochSeconds(end))).thenReturn(Optional.of(List.of(
+                eventResponse
+        )));
+        when(currencyRestTemplate.convertPrice(currencyConvertRequest)).thenReturn(Optional.of(1000D));
+        List<Event> events = eventService.getSuitableEvents(100D, "USD", null, null).join();
+
+        assertAll("Check response",
+                () -> assertThat(events.size()).isEqualTo(1),
+                () -> assertThat(events.getFirst().id()).isEqualTo(1L),
+                () -> assertThat(events.getFirst().price()).isEqualTo("бесплатно"));
+    }
+}

--- a/KudaGo/src/test/java/arden/java/kudago/service/EventServiceTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/EventServiceTest.java
@@ -3,8 +3,12 @@ package arden.java.kudago.service;
 import arden.java.kudago.dto.response.event.EventDto;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.model.Event;
+import arden.java.kudago.model.Location;
 import arden.java.kudago.repository.EventRepository;
+import arden.java.kudago.repository.LocationRepository;
 import arden.java.kudago.service.impl.EventServiceImpl;
+import arden.java.kudago.service.impl.LocationServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,16 +41,29 @@ public class EventServiceTest {
     private EventRepository eventRepository;
     @InjectMocks
     private EventServiceImpl eventService;
+    @Mock
+    private LocationServiceImpl locationService;
+    @Mock
+    private LocationRepository locationRepository;
 
-    private final List<Optional<Event>> events = List.of(
-            Optional.of(new Event(1L, "Party", OffsetDateTime.parse("2024-10-23T15:30:00+01:00"), null)),
-            Optional.of(new Event(2L, "Concert", OffsetDateTime.parse("2024-10-21T15:30:00+01:00"), null))
-    );
+    @BeforeEach
+    void setUp() {
+        Location location = new Location();
+        location.setId(1L);
 
-    private final List<EventDto> eventsList = List.of(
-            new EventDto("Party", OffsetDateTime.parse("2024-10-23T15:30:00+01:00"), null),
-            new EventDto("Concert", OffsetDateTime.parse("2024-10-21T15:30:00+01:00"), null)
-    );
+        events = List.of(
+                Optional.of(new Event(1L, "Party", OffsetDateTime.parse("2024-10-23T15:30:00+01:00"), location)),
+                Optional.of(new Event(2L, "Concert", OffsetDateTime.parse("2024-10-21T15:30:00+01:00"), location))
+        );
+
+        eventsList = List.of(
+                new EventDto("Party", OffsetDateTime.parse("2024-10-23T15:30:00+01:00"), 1L),
+                new EventDto("Concert", OffsetDateTime.parse("2024-10-21T15:30:00+01:00"), 1L)
+        );
+    }
+    private List<Optional<Event>> events;
+
+    private List<EventDto> eventsList;
 
     @Test
     @DisplayName("Getting all Events: success test")
@@ -74,6 +92,7 @@ public class EventServiceTest {
     @DisplayName("Getting Event by id: success test")
     public void getEventBySlug_successTest() {
         when(eventRepository.findById(1L)).thenReturn(events.getFirst());
+        when(locationRepository.findByIdEager(anyLong())).thenReturn(Optional.of(new Location()));
 
         EventDto EventDto = eventService.getEventById(1L);
 
@@ -92,6 +111,7 @@ public class EventServiceTest {
     @DisplayName("Create new Event: success test")
     public void createEvent_successTest() {
         when(eventRepository.save(any(Event.class))).thenReturn(events.getFirst().get());
+        when(locationRepository.findByIdEager(anyLong())).thenReturn(Optional.of(new Location()));
 
         EventDto EventDto = eventService.createEvent(eventsList.getFirst());
 
@@ -103,6 +123,7 @@ public class EventServiceTest {
     public void updateEvent_successTest() {
         when(eventRepository.save(any(Event.class))).thenReturn(events.getLast().get());
         when(eventRepository.findById(1L)).thenReturn(events.getFirst());
+        when(locationRepository.findByIdEager(anyLong())).thenReturn(Optional.of(new Location()));
 
         EventDto EventDto = eventService.updateEvent(1L, eventsList.getLast());
 

--- a/KudaGo/src/test/java/arden/java/kudago/service/LocationServiceTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/LocationServiceTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.Location;
+import arden.java.kudago.dto.response.places.Location;
 import arden.java.kudago.exception.CreationObjectException;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.repository.StorageRepository;

--- a/KudaGo/src/test/java/arden/java/kudago/service/LocationServiceTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/LocationServiceTest.java
@@ -1,9 +1,9 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.response.places.Location;
-import arden.java.kudago.exception.CreationObjectException;
+import arden.java.kudago.dto.response.places.LocationResponse;
 import arden.java.kudago.exception.IdNotFoundException;
-import arden.java.kudago.repository.StorageRepository;
+import arden.java.kudago.model.Location;
+import arden.java.kudago.repository.LocationRepository;
 import arden.java.kudago.service.impl.LocationServiceImpl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,113 +14,102 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class LocationServiceTest {
     @Mock
-    private StorageRepository<String, Location> storage;
+    private LocationRepository locationRepository;
     @InjectMocks
     private LocationServiceImpl locationService;
 
-    private final List<Location> locationsList = List.of(
-            new Location("shop", "Магазин здорового питания"),
-            new Location("cafe", "Кафе быстрого питания")
+    private final List<Optional<Location>> locations = List.of(
+            Optional.of(new Location(1L, "Магазин здорового питания", "shop", null)),
+            Optional.of(new Location(2L, "Кафе быстрого питания", "cafe", null))
+    );
+
+    private final List<LocationResponse> locationsList = List.of(
+            new LocationResponse("shop", "Магазин здорового питания"),
+            new LocationResponse("cafe", "Кафе быстрого питания")
     );
 
     @Test
     @DisplayName("Getting all locations: success test")
     public void getAllLocations_successTest() {
         //Arrange
-        when(storage.readAll()).thenReturn(locationsList);
+        when(locationRepository.findAll()).thenReturn(locations.stream().map(location -> location.get()).toList());
 
         //Act
-        List<Location> locations = locationService.getAllLocations();
+        List<LocationResponse> locationResponses = locationService.getAllLocations();
 
         //Assert
-        assertThat(locations).isEqualTo(locationsList);
+        assertThat(locationResponses).isEqualTo(locationsList);
     }
 
     @Test
     @DisplayName("Getting all locations: fail test")
     public void getAllLocations_failTest() {
-        when(storage.readAll()).thenReturn(Collections.emptyList());
+        when(locationRepository.findAll()).thenReturn(Collections.emptyList());
 
-        List<Location> locations = locationService.getAllLocations();
+        List<LocationResponse> locationResponses = locationService.getAllLocations();
 
-        assertThat(Collections.emptyList()).isEqualTo(locations);
+        assertThat(Collections.emptyList()).isEqualTo(locationResponses);
     }
 
     @Test
     @DisplayName("Getting Location by id: success test")
     public void getLocationBySlug_successTest() {
-        when(storage.read("shop")).thenReturn(locationsList.getFirst());
+        when(locationRepository.findById(1L)).thenReturn(locations.getFirst());
 
-        Location Location = locationService.getLocationBySlug("shop");
+        LocationResponse LocationResponse = locationService.getLocationById(1L);
 
-        assertThat(Location).isEqualTo(locationsList.getFirst());
+        assertThat(LocationResponse).isEqualTo(locationsList.getFirst());
     }
 
     @Test
     @DisplayName("Getting Location by id: fail test")
     public void getLocationBySlug_failTest() {
-        when(storage.read("shop")).thenReturn(null);
+        when(locationRepository.findById(1L)).thenThrow(new IdNotFoundException("id not found"));
 
-        assertThrows(IdNotFoundException.class, () -> locationService.getLocationBySlug("shop"));
+        assertThrows(IdNotFoundException.class, () -> locationService.getLocationById(1L));
     }
 
     @Test
     @DisplayName("Create new Location: success test")
     public void createLocation_successTest() {
-        when(storage.create("shop", locationsList.getFirst())).thenReturn(locationsList.getFirst());
+        when(locationRepository.save(any(Location.class))).thenReturn(locations.getFirst().get());
 
-        Location Location = locationService.createLocation(locationsList.getFirst());
+        LocationResponse LocationResponse = locationService.createLocation(locationsList.getFirst());
 
-        assertThat(Location).isEqualTo(locationsList.getFirst());
-    }
-
-    @Test
-    @DisplayName("Create new Location: fail test")
-    public void createLocation_failTest() {
-        when(storage.create("shop", locationsList.getFirst())).thenReturn(null);
-
-        assertThrows(CreationObjectException.class, () -> locationService.createLocation(locationsList.getFirst()));
+        assertThat(LocationResponse).isEqualTo(locationsList.getFirst());
     }
 
     @Test
     @DisplayName("Update Location: success test")
     public void updateLocation_successTest() {
-        when(storage.update("shop", locationsList.getLast())).thenReturn(locationsList.getLast());
-        when(storage.read("shop")).thenReturn(locationsList.getFirst());
+        when(locationRepository.save(any(Location.class))).thenReturn(locations.getLast().get());
+        when(locationRepository.findById(1L)).thenReturn(locations.getFirst());
 
-        Location Location = locationService.updateLocation("shop", locationsList.getLast());
+        LocationResponse LocationResponse = locationService.updateLocation(1L, locationsList.getLast());
 
-        assertThat(Location).isEqualTo(locationsList.getLast());
+        assertThat(LocationResponse).isEqualTo(locationsList.getLast());
     }
 
     @Test
     @DisplayName("Update Location: fail test")
     public void updateLocation_failTest() {
-        assertThrows(IdNotFoundException.class, () -> locationService.updateLocation("shop", locationsList.getLast()));
+        assertThrows(IdNotFoundException.class, () -> locationService.updateLocation(2L, locationsList.getLast()));
     }
 
     @Test
     @DisplayName("Delete Location: success test")
     public void deleteLocation_successTest() {
-        when(storage.read("shop")).thenReturn(locationsList.getFirst());
-        when(storage.delete("shop")).thenReturn(true);
-
-        boolean isDeleted = locationService.deleteLocation("shop");
-
-        assertThat(isDeleted).isTrue();
-    }
-
-    @Test
-    @DisplayName("Delete Location: fail test")
-    public void deleteLocation_failTest() {
-        assertThrows(IdNotFoundException.class, () -> locationService.deleteLocation(locationsList.getFirst().slug()));
+        assertDoesNotThrow(() -> locationService.deleteLocation(locations.getFirst().get().getId()));
     }
 }

--- a/KudaGo/src/test/java/arden/java/kudago/service/LocationServiceTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/LocationServiceTest.java
@@ -1,6 +1,6 @@
 package arden.java.kudago.service;
 
-import arden.java.kudago.dto.response.places.LocationResponse;
+import arden.java.kudago.dto.response.places.LocationDto;
 import arden.java.kudago.exception.IdNotFoundException;
 import arden.java.kudago.model.Location;
 import arden.java.kudago.repository.LocationRepository;
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,26 +31,26 @@ public class LocationServiceTest {
     private LocationServiceImpl locationService;
 
     private final List<Optional<Location>> locations = List.of(
-            Optional.of(new Location(1L, "Магазин здорового питания", "shop", null)),
-            Optional.of(new Location(2L, "Кафе быстрого питания", "cafe", null))
+            Optional.of(new Location(1L, "Магазин здорового питания", "shop", new HashSet<>())),
+            Optional.of(new Location(2L, "Кафе быстрого питания", "cafe", new HashSet<>()))
     );
 
-    private final List<LocationResponse> locationsList = List.of(
-            new LocationResponse("shop", "Магазин здорового питания"),
-            new LocationResponse("cafe", "Кафе быстрого питания")
+    private final List<LocationDto> locationsList = List.of(
+            new LocationDto("shop", "Магазин здорового питания"),
+            new LocationDto("cafe", "Кафе быстрого питания")
     );
 
     @Test
     @DisplayName("Getting all locations: success test")
     public void getAllLocations_successTest() {
         //Arrange
-        when(locationRepository.findAll()).thenReturn(locations.stream().map(location -> location.get()).toList());
+        when(locationRepository.findAll()).thenReturn(locations.stream().map(Optional::get).toList());
 
         //Act
-        List<LocationResponse> locationResponses = locationService.getAllLocations();
+        List<LocationDto> locationResponse = locationService.getAllLocations();
 
         //Assert
-        assertThat(locationResponses).isEqualTo(locationsList);
+        assertThat(locationResponse).isEqualTo(locationsList);
     }
 
     @Test
@@ -57,25 +58,25 @@ public class LocationServiceTest {
     public void getAllLocations_failTest() {
         when(locationRepository.findAll()).thenReturn(Collections.emptyList());
 
-        List<LocationResponse> locationResponses = locationService.getAllLocations();
+        List<LocationDto> locationResponse = locationService.getAllLocations();
 
-        assertThat(Collections.emptyList()).isEqualTo(locationResponses);
+        assertThat(Collections.emptyList()).isEqualTo(locationResponse);
     }
 
     @Test
     @DisplayName("Getting Location by id: success test")
     public void getLocationBySlug_successTest() {
-        when(locationRepository.findById(1L)).thenReturn(locations.getFirst());
+        when(locationRepository.findByIdEager(1L)).thenReturn(locations.getFirst());
 
-        LocationResponse LocationResponse = locationService.getLocationById(1L);
+        LocationDto LocationDto = locationService.getLocationById(1L);
 
-        assertThat(LocationResponse).isEqualTo(locationsList.getFirst());
+        assertThat(LocationDto).isEqualTo(locationsList.getFirst());
     }
 
     @Test
     @DisplayName("Getting Location by id: fail test")
     public void getLocationBySlug_failTest() {
-        when(locationRepository.findById(1L)).thenThrow(new IdNotFoundException("id not found"));
+        when(locationRepository.findByIdEager(1L)).thenThrow(new IdNotFoundException("id not found"));
 
         assertThrows(IdNotFoundException.class, () -> locationService.getLocationById(1L));
     }
@@ -85,20 +86,20 @@ public class LocationServiceTest {
     public void createLocation_successTest() {
         when(locationRepository.save(any(Location.class))).thenReturn(locations.getFirst().get());
 
-        LocationResponse LocationResponse = locationService.createLocation(locationsList.getFirst());
+        LocationDto LocationDto = locationService.createLocation(locationsList.getFirst());
 
-        assertThat(LocationResponse).isEqualTo(locationsList.getFirst());
+        assertThat(LocationDto).isEqualTo(locationsList.getFirst());
     }
 
     @Test
     @DisplayName("Update Location: success test")
     public void updateLocation_successTest() {
         when(locationRepository.save(any(Location.class))).thenReturn(locations.getLast().get());
-        when(locationRepository.findById(1L)).thenReturn(locations.getFirst());
+        when(locationRepository.findByIdEager(1L)).thenReturn(locations.getFirst());
 
-        LocationResponse LocationResponse = locationService.updateLocation(1L, locationsList.getLast());
+        LocationDto LocationDto = locationService.updateLocation(1L, locationsList.getLast());
 
-        assertThat(LocationResponse).isEqualTo(locationsList.getLast());
+        assertThat(LocationDto).isEqualTo(locationsList.getLast());
     }
 
     @Test

--- a/KudaGo/src/test/java/arden/java/kudago/service/SuitableEventServiceReactiveTest.java
+++ b/KudaGo/src/test/java/arden/java/kudago/service/SuitableEventServiceReactiveTest.java
@@ -1,0 +1,114 @@
+package arden.java.kudago.service;
+
+import arden.java.kudago.client.CurrencyRestTemplate;
+import arden.java.kudago.client.EventRestTemplate;
+import arden.java.kudago.dto.request.CurrencyConvertRequest;
+import arden.java.kudago.dto.response.event.EventResponse;
+import arden.java.kudago.dto.response.event.SuitableEvent;
+import arden.java.kudago.service.impl.SuitableEventServiceReactiveImpl;
+import arden.java.kudago.utils.DateParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class SuitableEventServiceReactiveTest {
+    @InjectMocks
+    private SuitableEventServiceReactiveImpl eventService;
+
+    @Mock
+    private CurrencyRestTemplate currencyRestTemplate;
+
+    @Mock
+    private EventRestTemplate eventRestTemplate;
+
+    @BeforeEach
+    void setUp() {
+        eventService = new SuitableEventServiceReactiveImpl(eventRestTemplate, currencyRestTemplate);
+    }
+
+    @Test
+    @DisplayName("Только одно из двух мероприятий подходит по цене")
+    void getSuitableEvents_differentPrices_successTest() {
+        CurrencyConvertRequest currencyConvertRequest = CurrencyConvertRequest.builder()
+                .fromCurrency("USD")
+                .toCurrency("RUB")
+                .amount(100D)
+                .build();
+        EventResponse suitableEventResponse = EventResponse.builder()
+                .id(1L)
+                .dates(List.of(new EventResponse.Dates(1727740800L, 1738368000L))) // от 01.10.24 до 01.02.25
+                .title("Фестиваль осени")
+                .description("Какой-то классный фестиваль")
+                .siteUrl("https://festival.ru")
+                .price("400.0")
+                .favoritesCount(30L)
+                .build();
+        EventResponse unsuitableEventResponse = EventResponse.builder()
+                .id(2L)
+                .dates(List.of(new EventResponse.Dates(1727740800L, 1738368000L))) // от 01.10.24 до 01.02.25
+                .title("Очень дорогое")
+                .description("Ну очень дорогое")
+                .siteUrl("https://expensive.ru")
+                .price("40000000.0")
+                .favoritesCount(30L)
+                .build();
+        LocalDate start = LocalDate.of(2024, 10, 1);
+        LocalDate end = LocalDate.of(2025, 3, 1);
+
+        when(eventRestTemplate.getEvents(DateParser.toEpochSeconds(start), DateParser.toEpochSeconds(end))).thenReturn(Optional.of(List.of(
+                suitableEventResponse,
+                unsuitableEventResponse
+        )));
+        when(currencyRestTemplate.convertPrice(currencyConvertRequest)).thenReturn(Optional.of(1000D));
+        List<SuitableEvent> suitableEvents = eventService.getSuitableEvents(100D, "USD", start, end).block();
+
+        assertAll("Check response",
+                () -> assertThat(suitableEvents.size()).isEqualTo(1),
+                () -> assertThat(suitableEvents.getFirst().id()).isEqualTo(1L));
+    }
+
+    @Test
+    @DisplayName("Дата не указана")
+    void getSuitableEvents_differentDates_successTest() {
+        CurrencyConvertRequest currencyConvertRequest = CurrencyConvertRequest.builder()
+                .fromCurrency("USD")
+                .toCurrency("RUB")
+                .amount(100D)
+                .build();
+        EventResponse eventResponse = EventResponse.builder()
+                .id(1L)
+                .dates(List.of(new EventResponse.Dates(1727740800L, 1738368000L))) // от 01.10.24 до 01.02.25
+                .title("Выставка")
+                .description("Бесплатная выставка")
+                .siteUrl("https://free.ru")
+                .price("0.0")
+                .favoritesCount(30L)
+                .build();
+
+        LocalDate start = LocalDate.now();
+        LocalDate end = LocalDate.now().plusWeeks(1);
+        when(eventRestTemplate.getEvents(DateParser.toEpochSeconds(start), DateParser.toEpochSeconds(end))).thenReturn(Optional.of(List.of(
+                eventResponse
+        )));
+        when(currencyRestTemplate.convertPrice(currencyConvertRequest)).thenReturn(Optional.of(1000D));
+        List<SuitableEvent> suitableEvents = eventService.getSuitableEvents(100D, "USD", null, null).block();
+
+        assertAll("Check response",
+                () -> assertThat(suitableEvents.size()).isEqualTo(1),
+                () -> assertThat(suitableEvents.getFirst().id()).isEqualTo(1L),
+                () -> assertThat(suitableEvents.getFirst().price()).isEqualTo("бесплатно"));
+    }
+}

--- a/KudaGo/src/test/resources/currency-stub.json
+++ b/KudaGo/src/test/resources/currency-stub.json
@@ -1,0 +1,26 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "POST",
+        "urlPath": "/convert",
+        "bodyPatterns": [
+          {
+            "matchesJsonPath": "$[?(@.fromCurrency == 'USD' && @.toCurrency == 'RUB' && @.amount == 100)]"
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "fromCurrency": "USD",
+          "toCurrency": "RUB",
+          "convertedAmount": 10000
+        }
+      }
+    }
+  ]
+}

--- a/KudaGo/src/test/resources/events-stub.json
+++ b/KudaGo/src/test/resources/events-stub.json
@@ -1,0 +1,62 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "urlPath": "/events",
+        "queryParameters": {
+          "expand": {
+            "equalTo": "location"
+          },
+          "actual_since": {
+            "matches": "\\d+"
+          },
+          "actual_until": {
+            "matches": "\\d+"
+          },
+          "fields": {
+            "equalTo": "id,dates,title,slug,description,site_url,price,favorites_count,location"
+          }
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "jsonBody": {
+          "results": [
+            {
+              "id": 1,
+              "dates": [
+                {
+                  "start": "1727740800",
+                  "end": "1730419199"
+                }
+              ],
+              "title": "Фестиваль осени",
+              "description": "Какой-то классный фестиваль",
+              "site_url": "https://festival.ru",
+              "price": "400.0",
+              "favorites_count": 30
+            },
+            {
+              "id": 2,
+              "dates": [
+                {
+                  "start": "1727740800",
+                  "end": "1730419099"
+                }
+              ],
+              "title": "Выставка в Эрмитаже",
+              "description": "Крутейшая выставка",
+              "site_url": "https://hermitage.ru",
+              "price": "800.0",
+              "favorites_count": 20
+            }
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Результаты выполнения запросов к API при разном числе потоков:
| Кол-во потоков | Время запроса по категориям (мс) | Время запроса по локациям (мс) |
|-------------------|--------------------------------------------------------|-------------------------------------------------------|
| 1                   | 421                                          | 689                                        |
| 2                   | 730                                           | 1072                                        |
| 5                   | 732                                           | 1060                                        |
| 8                   | 718                                           | 1039                                        |
| 10                  | 722                                           | 1082                                        |
| 15                  | 719                                           | 1046                                        |
| 20                  | 736                                           | 1052                                        |

Заметим, что время выполнения при увеличении потоков остается практически таким же, кроме случая однопоточности, в котором запросы выполняются быстрее, чем в множестве потоков.

Объяснить можно тем, что сами запросы к API являются блокирующими операциями, и их в принципе всего 2, поэтому многопоточность только замедляет время выполнения, поскольку для создания пула потоков и их поддержания требуются отдельные ресурсы, занимающие время выполнения